### PR TITLE
fix(infra): pass --coverage through turbo to vitest [VASTU-1A-104b]

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -76,7 +76,7 @@ jobs:
         run: pnpm prisma:generate
 
       - name: Run unit tests with coverage
-        run: pnpm test -- --coverage
+        run: turbo run test -- --coverage
 
       - name: Merge coverage summaries
         if: always()


### PR DESCRIPTION
## Summary
- Fix `pnpm test -- --coverage` failing because turbo interprets the `--coverage` flag
- Use `turbo run test -- --coverage` to correctly pass through to vitest

## Root cause
`pnpm test` runs `turbo run test`. When passing `-- --coverage`, pnpm forwards it to turbo which doesn't recognize `--coverage`. Using `turbo run test -- --coverage` directly tells turbo to pass the arg through to the underlying vitest command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)