### PR TITLE
feat(shell): session expiry detection [VASTU-1A-103]

### DIFF
--- a/packages/shell/src/app/(shell)/layout.tsx
+++ b/packages/shell/src/app/(shell)/layout.tsx
@@ -16,6 +16,7 @@ import { getSessionWithAbility } from '@/lib/session';
 import { isAdmin } from '@vastu/shared/permissions';
 import { TopBar } from '@/components/shell/TopBar';
 import { SideNav } from '@/components/shell/SideNav';
+import { SessionGuard } from '@/components/auth/SessionGuard';
 import classes from '@/components/shell/ShellLayout.module.css';
 
 export default async function ShellLayout({ children }: { children: React.ReactNode }) {
@@ -32,6 +33,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
 
   return (
     <div className={classes.shell}>
+      <SessionGuard />
       <TopBar
         userName={userName}
         userEmail={userEmail}

--- a/packages/shell/src/app/workspace/layout.tsx
+++ b/packages/shell/src/app/workspace/layout.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { IconRail } from '@/components/workspace/IconRail';
+import { SessionGuard } from '@/components/auth/SessionGuard';
 import classes from './layout.module.css';
 
 export default function WorkspaceLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className={classes.container}>
+      <SessionGuard />
       <IconRail />
       <main className={classes.main}>{children}</main>
     </div>

--- a/packages/shell/src/components/auth/SessionGuard.tsx
+++ b/packages/shell/src/components/auth/SessionGuard.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+/**
+ * SessionGuard — Polls the session on a 60-second interval and redirects
+ * to the login page with ?expired=true when the session is no longer valid.
+ *
+ * Mount this in any layout that requires authentication (shell, workspace).
+ * Do NOT mount in the auth layout — login/register pages don't need session checks.
+ *
+ * Renders nothing visible; purely a side-effect component.
+ *
+ * Implementation note: Uses direct fetch to /api/auth/session instead of
+ * next-auth's useSession hook to avoid requiring a SessionProvider in the
+ * component tree. The session endpoint returns 200 with an empty object
+ * when unauthenticated, so we check for the presence of user data.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { showWarning } from '@/lib/notifications';
+import { t } from '@/lib/i18n';
+
+export const SESSION_CHECK_INTERVAL_MS = 60_000;
+
+/** Routes where session checks should be skipped to avoid redirect loops. */
+const AUTH_ROUTES = [
+  '/login',
+  '/register',
+  '/forgot-password',
+  '/reset-password',
+  '/verify-email',
+  '/sso',
+  '/mfa',
+];
+
+function isAuthRoute(pathname: string): boolean {
+  return AUTH_ROUTES.some((route) => pathname.startsWith(route));
+}
+
+async function checkSession(): Promise<boolean> {
+  try {
+    const res = await fetch('/api/auth/session');
+    if (!res.ok) return false;
+    const data = (await res.json()) as Record<string, unknown>;
+    // next-auth returns 200 with {} when unauthenticated.
+    return Boolean(data.user);
+  } catch {
+    // Network error — don't redirect, let the next poll retry.
+    return true;
+  }
+}
+
+export function SessionGuard() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const hasRedirected = useRef(false);
+
+  useEffect(() => {
+    if (isAuthRoute(pathname)) return;
+
+    const interval = setInterval(() => {
+      void checkSession().then((valid) => {
+        if (!valid && !hasRedirected.current) {
+          hasRedirected.current = true;
+          showWarning(t('error.sessionExpired'));
+          router.push('/login?expired=true');
+        }
+      });
+    }, SESSION_CHECK_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [pathname, router]);
+
+  return null;
+}

--- a/packages/shell/src/components/auth/__tests__/SessionGuard.test.tsx
+++ b/packages/shell/src/components/auth/__tests__/SessionGuard.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { SessionGuard } from '../SessionGuard';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+const mockPathname = vi.fn(() => '/settings');
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname(),
+}));
+
+// Mock notifications
+const mockShowWarning = vi.fn();
+vi.mock('@/lib/notifications', () => ({
+  showWarning: (...args: unknown[]) => mockShowWarning(...args),
+}));
+
+// Mock i18n
+vi.mock('@/lib/i18n', () => ({
+  t: (key: string) => key,
+}));
+
+describe('SessionGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname.mockReturnValue('/settings');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing visible', () => {
+    const { container } = render(<SessionGuard />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('sets up an interval on mount (non-auth page)', () => {
+    const spy = vi.spyOn(global, 'setInterval');
+    render(<SessionGuard />);
+    expect(spy).toHaveBeenCalledWith(expect.any(Function), 60_000);
+  });
+
+  it('does not set up an interval on auth pages', () => {
+    const spy = vi.spyOn(global, 'setInterval');
+    mockPathname.mockReturnValue('/login');
+    render(<SessionGuard />);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('clears interval on unmount', () => {
+    const spy = vi.spyOn(global, 'clearInterval');
+    const { unmount } = render(<SessionGuard />);
+    unmount();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('skips interval on all auth routes', () => {
+    const spy = vi.spyOn(global, 'setInterval');
+    for (const route of ['/login', '/register', '/forgot-password', '/reset-password', '/verify-email', '/sso', '/mfa']) {
+      spy.mockClear();
+      mockPathname.mockReturnValue(route);
+      render(<SessionGuard />);
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/shell/src/components/auth/index.ts
+++ b/packages/shell/src/components/auth/index.ts
@@ -14,3 +14,4 @@ export { OtpInput } from './OtpInput';
 export type { OtpInputProps } from './OtpInput';
 export { RecoveryCodes } from './RecoveryCodes';
 export type { RecoveryCodesProps } from './RecoveryCodes';
+export { SessionGuard } from './SessionGuard';


### PR DESCRIPTION
## Summary
- Add `SessionGuard` component that polls `/api/auth/session` every 60 seconds
- On expired session: shows warning toast and redirects to `/login?expired=true`
- Integrated into shell layout (settings/admin) and workspace layout
- Skips all auth routes to prevent redirect loops
- Network errors handled gracefully (no false redirects)
- LoginForm already handles `?expired=true` display (from Phase 0)

Closes #80

## QA Results
All 4 acceptance criteria verified and passed.

## Test plan
- [x] AC-1: 60-second polling interval via setInterval
- [x] AC-2: Toast + redirect to `/login?expired=true` on expiry
- [x] AC-3: Login page shows "Session expired" message (pre-existing)
- [x] AC-4: No redirect loop — 7 auth routes excluded
- [x] 5 unit tests pass
- [x] Network error graceful handling verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)