### PR TITLE
feat(workspace): view state store with Prisma models and API routes [VASTU-1A-110]

### DIFF
--- a/packages/shared/src/prisma/migrations/20260320000001_add_pages_and_views/migration.sql
+++ b/packages/shared/src/prisma/migrations/20260320000001_add_pages_and_views/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable: pages
+CREATE TABLE "pages" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "icon" TEXT,
+    "template_type" TEXT NOT NULL,
+    "organization_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "pages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: views
+CREATE TABLE "views" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "page_id" TEXT NOT NULL,
+    "state_json" JSONB NOT NULL,
+    "created_by" TEXT NOT NULL,
+    "is_shared" BOOLEAN NOT NULL DEFAULT false,
+    "color_dot" TEXT,
+    "organization_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "views_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pages_slug_key" ON "pages"("slug");
+CREATE INDEX "pages_organization_id_idx" ON "pages"("organization_id");
+CREATE INDEX "views_page_id_idx" ON "views"("page_id");
+CREATE INDEX "views_created_by_idx" ON "views"("created_by");
+CREATE INDEX "views_organization_id_idx" ON "views"("organization_id");
+
+-- AddForeignKey
+ALTER TABLE "pages" ADD CONSTRAINT "pages_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "views" ADD CONSTRAINT "views_page_id_fkey" FOREIGN KEY ("page_id") REFERENCES "pages"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "views" ADD CONSTRAINT "views_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "views" ADD CONSTRAINT "views_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/shared/src/prisma/schema.prisma
+++ b/packages/shared/src/prisma/schema.prisma
@@ -54,6 +54,8 @@ model Organization {
   dbConnections DbConnection[]
   ssoProviders  SsoProvider[]
   auditEvents   AuditEvent[]
+  pages         Page[]
+  views         View[]
 
   @@map("organizations")
 }
@@ -87,6 +89,7 @@ model User {
   auditEvents  AuditEvent[]
   sessions     Session[]
   accounts     Account[]
+  views        View[]
 
   @@index([organizationId])
   @@index([email])
@@ -338,4 +341,53 @@ model VerificationToken {
 
   @@unique([identifier, token])
   @@map("verification_tokens")
+}
+
+// ---------------------------------------------------------------------------
+// Page — registered page definitions (US-110)
+// ---------------------------------------------------------------------------
+
+model Page {
+  id             String    @id @default(uuid())
+  name           String
+  slug           String    @unique
+  icon           String?
+  templateType   String    @map("template_type")
+  organizationId String    @map("organization_id")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
+  deletedAt      DateTime? @map("deleted_at")
+
+  organization Organization @relation(fields: [organizationId], references: [id])
+  views        View[]
+
+  @@index([organizationId])
+  @@map("pages")
+}
+
+// ---------------------------------------------------------------------------
+// View — saved view state snapshots (US-110)
+// ---------------------------------------------------------------------------
+
+model View {
+  id             String    @id @default(uuid())
+  name           String
+  pageId         String    @map("page_id")
+  stateJson      Json      @map("state_json")
+  createdBy      String    @map("created_by")
+  isShared       Boolean   @default(false) @map("is_shared")
+  colorDot       String?   @map("color_dot")
+  organizationId String    @map("organization_id")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
+  deletedAt      DateTime? @map("deleted_at")
+
+  page          Page         @relation(fields: [pageId], references: [id])
+  createdByUser User         @relation(fields: [createdBy], references: [id])
+  organization  Organization @relation(fields: [organizationId], references: [id])
+
+  @@index([pageId])
+  @@index([createdBy])
+  @@index([organizationId])
+  @@map("views")
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -45,3 +45,18 @@ export type {
   CreateDbConnectionInput,
   UpdateDbConnectionInput,
 } from './db-connection';
+
+export type { Page } from './page';
+
+export type {
+  View,
+  ViewState,
+  FilterNode,
+  FilterCondition,
+  FilterGroup,
+  FilterMode,
+  DataType,
+  SortState,
+  ColumnState,
+  PaginationState,
+} from './view';

--- a/packages/shared/src/types/page.ts
+++ b/packages/shared/src/types/page.ts
@@ -1,0 +1,16 @@
+/**
+ * Page type — represents a registered page definition.
+ * Minimal in Phase 1A; expanded in Phase 1B with template configs.
+ */
+
+export interface Page {
+  id: string;
+  name: string;
+  slug: string;
+  icon: string | null;
+  templateType: string;
+  organizationId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}

--- a/packages/shared/src/types/view.ts
+++ b/packages/shared/src/types/view.ts
@@ -1,0 +1,75 @@
+/**
+ * View types — saved view state snapshots.
+ *
+ * A View persists the state of a page's data presentation (filters, sort,
+ * columns, pagination) so users can save and share different perspectives.
+ */
+
+/** Filter mode: include matches, exclude matches, or regex match. */
+export type FilterMode = 'include' | 'exclude' | 'regex';
+
+/** Supported data types for filter inputs. */
+export type DataType = 'text' | 'number' | 'date' | 'enum' | 'boolean';
+
+/** A single filter condition on one field. */
+export interface FilterCondition {
+  type: 'condition';
+  field: string;
+  mode: FilterMode;
+  dataType: DataType;
+  value: unknown;
+}
+
+/** A group of filter conditions combined with AND or OR. */
+export interface FilterGroup {
+  type: 'group';
+  operator: 'and' | 'or';
+  children: FilterNode[];
+}
+
+/** Recursive filter tree node — either a condition or a group. */
+export type FilterNode = FilterCondition | FilterGroup;
+
+/** Sort direction for a column. */
+export interface SortState {
+  field: string;
+  direction: 'asc' | 'desc';
+}
+
+/** Column visibility and sizing state. */
+export interface ColumnState {
+  id: string;
+  visible: boolean;
+  width?: number;
+  order: number;
+}
+
+/** Pagination state. */
+export interface PaginationState {
+  page: number;
+  pageSize: number;
+}
+
+/** Complete view state — everything needed to restore a view. */
+export interface ViewState {
+  filters: FilterNode | null;
+  sort: SortState[];
+  columns: ColumnState[];
+  pagination: PaginationState;
+  scrollPosition: { x: number; y: number };
+}
+
+/** Persisted view record from the database. */
+export interface View {
+  id: string;
+  name: string;
+  pageId: string;
+  stateJson: ViewState;
+  createdBy: string;
+  isShared: boolean;
+  colorDot: string | null;
+  organizationId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}

--- a/packages/shell/src/app/api/workspace/views/[id]/route.ts
+++ b/packages/shell/src/app/api/workspace/views/[id]/route.ts
@@ -1,0 +1,127 @@
+/**
+ * GET /api/workspace/views/[id] — get a single view
+ * PATCH /api/workspace/views/[id] — update a view
+ * DELETE /api/workspace/views/[id] — soft-delete a view
+ *
+ * US-110: View state store API routes.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { prisma } from '@vastu/shared/prisma';
+import { getSession } from '@/lib/session';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const view = await prisma.view.findFirst({
+    where: {
+      id,
+      organizationId: session.user.organizationId,
+      deletedAt: null,
+      OR: [
+        { createdBy: session.user.id },
+        { isShared: true },
+      ],
+    },
+  });
+
+  if (!view) {
+    return NextResponse.json({ error: 'View not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(view);
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  // Only the creator can update a view
+  const existing = await prisma.view.findFirst({
+    where: {
+      id,
+      createdBy: session.user.id,
+      organizationId: session.user.organizationId,
+      deletedAt: null,
+    },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: 'View not found or not owned by you' }, { status: 404 });
+  }
+
+  const body = (await request.json()) as {
+    name?: string;
+    stateJson?: unknown;
+    isShared?: boolean;
+    colorDot?: string | null;
+  };
+
+  // Validate stateJson size if provided
+  if (body.stateJson) {
+    const stateSize = JSON.stringify(body.stateJson).length;
+    if (stateSize > 100_000) {
+      return NextResponse.json(
+        { error: 'View state exceeds 100KB limit' },
+        { status: 413 },
+      );
+    }
+  }
+
+  const view = await prisma.view.update({
+    where: { id },
+    data: {
+      ...(body.name !== undefined && { name: body.name }),
+      ...(body.stateJson !== undefined && { stateJson: body.stateJson as object }),
+      ...(body.isShared !== undefined && { isShared: body.isShared }),
+      ...(body.colorDot !== undefined && { colorDot: body.colorDot }),
+    },
+  });
+
+  return NextResponse.json(view);
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  // Only the creator can delete a view
+  const existing = await prisma.view.findFirst({
+    where: {
+      id,
+      createdBy: session.user.id,
+      organizationId: session.user.organizationId,
+      deletedAt: null,
+    },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: 'View not found or not owned by you' }, { status: 404 });
+  }
+
+  // Soft-delete
+  await prisma.view.update({
+    where: { id },
+    data: { deletedAt: new Date() },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/packages/shell/src/app/api/workspace/views/route.ts
+++ b/packages/shell/src/app/api/workspace/views/route.ts
@@ -1,0 +1,85 @@
+/**
+ * GET /api/workspace/views?pageId=X — list views for a page (user's own + shared)
+ * POST /api/workspace/views — create a new view
+ *
+ * US-110: View state store API routes.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { prisma } from '@vastu/shared/prisma';
+import { getSession } from '@/lib/session';
+
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const pageId = searchParams.get('pageId');
+
+  if (!pageId) {
+    return NextResponse.json({ error: 'pageId is required' }, { status: 400 });
+  }
+
+  const views = await prisma.view.findMany({
+    where: {
+      pageId,
+      organizationId: session.user.organizationId,
+      deletedAt: null,
+      OR: [
+        { createdBy: session.user.id },
+        { isShared: true },
+      ],
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+
+  return NextResponse.json(views);
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = (await request.json()) as {
+    name: string;
+    pageId: string;
+    stateJson: unknown;
+    colorDot?: string;
+    isShared?: boolean;
+  };
+
+  if (!body.name || !body.pageId || !body.stateJson) {
+    return NextResponse.json(
+      { error: 'name, pageId, and stateJson are required' },
+      { status: 400 },
+    );
+  }
+
+  // Validate stateJson size (warn at 100KB)
+  const stateSize = JSON.stringify(body.stateJson).length;
+  if (stateSize > 100_000) {
+    return NextResponse.json(
+      { error: 'View state exceeds 100KB limit' },
+      { status: 413 },
+    );
+  }
+
+  const view = await prisma.view.create({
+    data: {
+      name: body.name,
+      pageId: body.pageId,
+      stateJson: body.stateJson as object,
+      createdBy: session.user.id,
+      isShared: body.isShared ?? false,
+      colorDot: body.colorDot ?? null,
+      organizationId: session.user.organizationId,
+    },
+  });
+
+  return NextResponse.json(view, { status: 201 });
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -28,6 +28,7 @@ export { WelcomePanel, WELCOME_PANEL_TYPE_ID } from './panels/WelcomePanel';
 export { useSidebarStore } from './stores/sidebarStore';
 export { usePanelStore, openPanelByTypeId } from './stores/panelStore';
 export { useTrayStore } from './stores/trayStore';
+export { useViewStore } from './stores/viewStore';
 
 // Hooks
 export { usePanelPersistence, PANEL_LAYOUT_STORAGE_KEY } from './hooks/usePanelPersistence';

--- a/packages/workspace/src/stores/__tests__/viewStore.test.ts
+++ b/packages/workspace/src/stores/__tests__/viewStore.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useViewStore } from '../viewStore';
+import type { ViewState } from '@vastu/shared/types';
+
+const mockViewState: ViewState = {
+  filters: { type: 'condition', field: 'name', mode: 'include', dataType: 'text', value: 'test' },
+  sort: [{ field: 'name', direction: 'asc' }],
+  columns: [{ id: 'name', visible: true, order: 0 }],
+  pagination: { page: 1, pageSize: 25 },
+  scrollPosition: { x: 0, y: 0 },
+};
+
+describe('viewStore', () => {
+  beforeEach(() => {
+    useViewStore.setState({
+      currentViewId: null,
+      savedState: null,
+      currentState: {
+        filters: null,
+        sort: [],
+        columns: [],
+        pagination: { page: 1, pageSize: 25 },
+        scrollPosition: { x: 0, y: 0 },
+      },
+    });
+    vi.restoreAllMocks();
+  });
+
+  describe('isModified', () => {
+    it('returns false when savedState is null', () => {
+      expect(useViewStore.getState().isModified()).toBe(false);
+    });
+
+    it('returns false when currentState equals savedState', () => {
+      useViewStore.setState({
+        savedState: { ...mockViewState },
+        currentState: { ...mockViewState },
+      });
+      expect(useViewStore.getState().isModified()).toBe(false);
+    });
+
+    it('returns true when filters differ', () => {
+      useViewStore.setState({
+        savedState: { ...mockViewState },
+        currentState: { ...mockViewState, filters: null },
+      });
+      expect(useViewStore.getState().isModified()).toBe(true);
+    });
+
+    it('returns true when sort differs', () => {
+      useViewStore.setState({
+        savedState: { ...mockViewState },
+        currentState: { ...mockViewState, sort: [{ field: 'name', direction: 'desc' }] },
+      });
+      expect(useViewStore.getState().isModified()).toBe(true);
+    });
+
+    it('ignores scrollPosition changes', () => {
+      useViewStore.setState({
+        savedState: { ...mockViewState },
+        currentState: { ...mockViewState, scrollPosition: { x: 100, y: 200 } },
+      });
+      expect(useViewStore.getState().isModified()).toBe(false);
+    });
+  });
+
+  describe('updateFilters', () => {
+    it('updates the filter state', () => {
+      const filter = { type: 'condition' as const, field: 'status', mode: 'include' as const, dataType: 'enum' as const, value: 'active' };
+      useViewStore.getState().updateFilters(filter);
+      expect(useViewStore.getState().currentState.filters).toEqual(filter);
+    });
+  });
+
+  describe('updateSort', () => {
+    it('updates the sort state', () => {
+      const sort = [{ field: 'date', direction: 'desc' as const }];
+      useViewStore.getState().updateSort(sort);
+      expect(useViewStore.getState().currentState.sort).toEqual(sort);
+    });
+  });
+
+  describe('updateColumns', () => {
+    it('updates the column state', () => {
+      const columns = [{ id: 'name', visible: true, order: 0 }, { id: 'email', visible: false, order: 1 }];
+      useViewStore.getState().updateColumns(columns);
+      expect(useViewStore.getState().currentState.columns).toEqual(columns);
+    });
+  });
+
+  describe('updatePagination', () => {
+    it('updates page and pageSize', () => {
+      useViewStore.getState().updatePagination(3, 50);
+      expect(useViewStore.getState().currentState.pagination).toEqual({ page: 3, pageSize: 50 });
+    });
+  });
+
+  describe('resetView', () => {
+    it('resets currentState to savedState', () => {
+      useViewStore.setState({
+        savedState: { ...mockViewState },
+        currentState: { ...mockViewState, filters: null, sort: [] },
+      });
+      useViewStore.getState().resetView();
+      expect(useViewStore.getState().currentState.filters).toEqual(mockViewState.filters);
+      expect(useViewStore.getState().currentState.sort).toEqual(mockViewState.sort);
+    });
+
+    it('does nothing when savedState is null', () => {
+      const before = { ...useViewStore.getState().currentState };
+      useViewStore.getState().resetView();
+      expect(useViewStore.getState().currentState).toEqual(before);
+    });
+  });
+
+  describe('setViewState', () => {
+    it('sets currentState and savedState with viewId', () => {
+      useViewStore.getState().setViewState(mockViewState, 'view-1');
+      expect(useViewStore.getState().currentViewId).toBe('view-1');
+      expect(useViewStore.getState().savedState).toEqual(mockViewState);
+      expect(useViewStore.getState().currentState).toEqual(mockViewState);
+    });
+
+    it('sets currentState without savedState when no viewId', () => {
+      useViewStore.getState().setViewState(mockViewState);
+      expect(useViewStore.getState().currentViewId).toBeNull();
+      expect(useViewStore.getState().savedState).toBeNull();
+      expect(useViewStore.getState().currentState).toEqual(mockViewState);
+    });
+  });
+
+  describe('saveView', () => {
+    it('creates a new view when no currentViewId', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'new-view-id' }),
+      });
+      global.fetch = mockFetch;
+
+      useViewStore.setState({ currentState: mockViewState, currentViewId: null });
+      await useViewStore.getState().saveView('My View', 'page-1');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/workspace/views', expect.objectContaining({ method: 'POST' }));
+      expect(useViewStore.getState().currentViewId).toBe('new-view-id');
+      expect(useViewStore.getState().savedState).toEqual(mockViewState);
+    });
+
+    it('updates existing view when currentViewId is set', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      global.fetch = mockFetch;
+
+      useViewStore.setState({ currentState: mockViewState, currentViewId: 'existing-id' });
+      await useViewStore.getState().saveView('Updated', 'page-1');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/workspace/views/existing-id', expect.objectContaining({ method: 'PATCH' }));
+      expect(useViewStore.getState().currentViewId).toBe('existing-id');
+    });
+
+    it('throws on failed save', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false });
+      useViewStore.setState({ currentViewId: 'id' });
+
+      await expect(useViewStore.getState().saveView('Test', 'page-1')).rejects.toThrow('Failed to save view');
+    });
+  });
+
+  describe('loadView', () => {
+    it('loads view state from API', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ stateJson: mockViewState }),
+      });
+
+      await useViewStore.getState().loadView('view-1');
+
+      expect(useViewStore.getState().currentViewId).toBe('view-1');
+      expect(useViewStore.getState().currentState.filters).toEqual(mockViewState.filters);
+    });
+
+    it('throws on failed load', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false });
+
+      await expect(useViewStore.getState().loadView('bad-id')).rejects.toThrow('Failed to load view');
+    });
+  });
+});

--- a/packages/workspace/src/stores/viewStore.ts
+++ b/packages/workspace/src/stores/viewStore.ts
@@ -1,0 +1,195 @@
+'use client';
+
+/**
+ * viewStore — manages the current view state (filters, sort, columns, pagination).
+ *
+ * The view store is consumed by ViewToolbar (US-111), VastuTable (US-112),
+ * and FilterSystem (US-114). It is a headless store with no UI.
+ *
+ * isModified compares currentState vs savedState, ignoring scrollPosition.
+ *
+ * Implements US-110 (AC-1 through AC-9).
+ */
+
+import { create } from 'zustand';
+import type {
+  ViewState,
+  FilterNode,
+  SortState,
+  ColumnState,
+} from '@vastu/shared/types';
+
+/** Default empty view state. */
+const DEFAULT_VIEW_STATE: ViewState = {
+  filters: null,
+  sort: [],
+  columns: [],
+  pagination: { page: 1, pageSize: 25 },
+  scrollPosition: { x: 0, y: 0 },
+};
+
+interface ViewStoreState {
+  /** ID of the currently loaded view (null if unsaved). */
+  currentViewId: string | null;
+  /** The last saved snapshot — used for isModified comparison. */
+  savedState: ViewState | null;
+  /** The live working state. */
+  currentState: ViewState;
+
+  // ---- Computed ----
+
+  /** True when currentState differs from savedState (ignoring scrollPosition). */
+  isModified: () => boolean;
+
+  // ---- Actions ----
+
+  /** Save the current state as a named view via API. */
+  saveView: (name: string, pageId: string) => Promise<void>;
+  /** Load a view from the API by ID. */
+  loadView: (id: string) => Promise<void>;
+  /** Reset current state to the last saved state. */
+  resetView: () => void;
+  /** Update filter state. */
+  updateFilters: (filters: FilterNode | null) => void;
+  /** Update sort state. */
+  updateSort: (sort: SortState[]) => void;
+  /** Update column state. */
+  updateColumns: (columns: ColumnState[]) => void;
+  /** Update pagination. */
+  updatePagination: (page: number, pageSize: number) => void;
+  /** Update scroll position. */
+  updateScrollPosition: (x: number, y: number) => void;
+  /** Set full view state (used when loading). */
+  setViewState: (state: ViewState, viewId?: string) => void;
+}
+
+/**
+ * Compare two ViewState objects for equality, ignoring scrollPosition.
+ * Used to compute isModified.
+ */
+function viewStatesEqual(a: ViewState, b: ViewState): boolean {
+  return (
+    JSON.stringify({
+      filters: a.filters,
+      sort: a.sort,
+      columns: a.columns,
+      pagination: a.pagination,
+    }) ===
+    JSON.stringify({
+      filters: b.filters,
+      sort: b.sort,
+      columns: b.columns,
+      pagination: b.pagination,
+    })
+  );
+}
+
+export const useViewStore = create<ViewStoreState>()((set, get) => ({
+  currentViewId: null,
+  savedState: null,
+  currentState: { ...DEFAULT_VIEW_STATE },
+
+  isModified: () => {
+    const { savedState, currentState } = get();
+    if (!savedState) return false;
+    return !viewStatesEqual(currentState, savedState);
+  },
+
+  saveView: async (name: string, pageId: string) => {
+    const { currentState, currentViewId } = get();
+    const body = {
+      name,
+      pageId,
+      stateJson: currentState,
+    };
+
+    let viewId = currentViewId;
+
+    if (currentViewId) {
+      // Update existing view
+      const res = await fetch(`/api/workspace/views/${currentViewId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error('Failed to save view');
+    } else {
+      // Create new view
+      const res = await fetch('/api/workspace/views', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error('Failed to create view');
+      const data = (await res.json()) as { id: string };
+      viewId = data.id;
+    }
+
+    set({
+      currentViewId: viewId,
+      savedState: { ...currentState },
+    });
+  },
+
+  loadView: async (id: string) => {
+    const res = await fetch(`/api/workspace/views/${id}`);
+    if (!res.ok) throw new Error('Failed to load view');
+    const data = (await res.json()) as { stateJson: ViewState };
+
+    const viewState: ViewState = {
+      ...DEFAULT_VIEW_STATE,
+      ...data.stateJson,
+    };
+
+    set({
+      currentViewId: id,
+      savedState: { ...viewState },
+      currentState: { ...viewState },
+    });
+  },
+
+  resetView: () => {
+    const { savedState } = get();
+    if (savedState) {
+      set({ currentState: { ...savedState } });
+    }
+  },
+
+  updateFilters: (filters) =>
+    set((state) => ({
+      currentState: { ...state.currentState, filters },
+    })),
+
+  updateSort: (sort) =>
+    set((state) => ({
+      currentState: { ...state.currentState, sort },
+    })),
+
+  updateColumns: (columns) =>
+    set((state) => ({
+      currentState: { ...state.currentState, columns },
+    })),
+
+  updatePagination: (page, pageSize) =>
+    set((state) => ({
+      currentState: {
+        ...state.currentState,
+        pagination: { page, pageSize },
+      },
+    })),
+
+  updateScrollPosition: (x, y) =>
+    set((state) => ({
+      currentState: {
+        ...state.currentState,
+        scrollPosition: { x, y },
+      },
+    })),
+
+  setViewState: (viewState, viewId) =>
+    set({
+      currentViewId: viewId ?? null,
+      savedState: viewId ? { ...viewState } : null,
+      currentState: { ...viewState },
+    }),
+}));


### PR DESCRIPTION
## Summary
- Add Page and View Prisma models with migration (pages, views tables)
- Shared types: ViewState, FilterNode, FilterCondition, FilterGroup, SortState, ColumnState, PaginationState
- viewStore (Zustand): save/load/reset views, isModified detection (ignores scrollPosition)
- API routes: CRUD for views, scoped to org + user ownership, soft-delete, 100KB state limit
- 109 workspace tests pass (18 new)

## Verified locally
- [x] lint passes
- [x] typecheck passes
- [x] 109 tests pass
- [x] shell build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)