### PR TITLE
feat(workspace): mode switch segmented control with IER modes [VASTU-1A-108]

### DIFF
--- a/packages/workspace/messages/en.json
+++ b/packages/workspace/messages/en.json
@@ -17,6 +17,11 @@
   "filter.mode.regex.short": "R",
   "filter.mode.ariaLabel": "Filter mode",
 
+  "filter.modeSwitch.ariaLabel": "Filter mode switch",
+  "filter.modeSwitch.include.tooltip": "Include rows matching this value",
+  "filter.modeSwitch.exclude.tooltip": "Exclude rows matching this value",
+  "filter.modeSwitch.regex.tooltip": "Match rows against a regular expression",
+
   "filter.bar.addFilter": "+ Add filter",
   "filter.bar.advanced": "Advanced",
   "filter.bar.simple": "Simple",

--- a/packages/workspace/src/components/ModeSwitch/ModeSwitch.module.css
+++ b/packages/workspace/src/components/ModeSwitch/ModeSwitch.module.css
@@ -1,0 +1,127 @@
+/**
+ * ModeSwitch styles.
+ * All colors via --v-* CSS custom properties.
+ * Implements the IER segmented control appearance.
+ */
+
+/* Container — inline flex row of segments */
+.root {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--v-radius-sm);
+  border: 1px solid var(--v-border-default);
+  background-color: var(--v-bg-secondary);
+  overflow: hidden;
+  gap: 0;
+}
+
+.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Individual segment button */
+.segment {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--v-space-1);
+  padding: 0 var(--v-space-2);
+  height: 28px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: var(--v-font-sans);
+  font-size: var(--v-text-xs);
+  font-weight: var(--v-font-medium);
+  color: var(--v-text-secondary);
+  transition:
+    background-color var(--v-duration-fast) var(--v-ease-default),
+    color var(--v-duration-fast) var(--v-ease-default);
+  white-space: nowrap;
+  /* Separator between segments */
+  border-right: 1px solid var(--v-border-default);
+}
+
+.segment:last-child {
+  border-right: none;
+}
+
+.segment:disabled {
+  cursor: not-allowed;
+}
+
+/* Inactive hover state */
+.inactive:hover:not(:disabled) {
+  background-color: var(--v-bg-tertiary);
+  color: var(--v-text-primary);
+}
+
+/* Short single-letter badge */
+.short {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--v-radius-sm);
+  font-size: var(--v-text-xs);
+  font-weight: var(--v-font-medium);
+  flex-shrink: 0;
+}
+
+/* Full mode label — shown next to the short badge */
+.label {
+  font-size: var(--v-text-xs);
+}
+
+/* ---- Active states ---- */
+
+/* Base active styles */
+.active {
+  font-weight: var(--v-font-medium);
+}
+
+/* Include mode — accent-primary (blue) */
+.activeInclude {
+  background-color: var(--v-accent-primary-light);
+  color: var(--v-accent-primary);
+}
+
+.activeInclude .short {
+  background-color: var(--v-accent-primary);
+  color: var(--v-bg-primary);
+}
+
+.activeInclude:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--v-accent-primary) 18%, transparent);
+}
+
+/* Exclude mode — status-error (red) */
+.activeExclude {
+  background-color: var(--v-status-error-light);
+  color: var(--v-status-error);
+}
+
+.activeExclude .short {
+  background-color: var(--v-status-error);
+  color: var(--v-bg-primary);
+}
+
+.activeExclude:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--v-status-error) 18%, transparent);
+}
+
+/* Regex mode — accent-quaternary (muted violet) */
+.activeRegex {
+  background-color: var(--v-accent-quaternary-light);
+  color: var(--v-accent-quaternary);
+}
+
+.activeRegex .short {
+  background-color: var(--v-accent-quaternary);
+  color: var(--v-bg-primary);
+}
+
+.activeRegex:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--v-accent-quaternary) 18%, transparent);
+}

--- a/packages/workspace/src/components/ModeSwitch/ModeSwitch.tsx
+++ b/packages/workspace/src/components/ModeSwitch/ModeSwitch.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+/**
+ * ModeSwitch — IER (Include/Exclude/Regex) segmented control.
+ *
+ * A standalone, visually prominent mode switcher that allows toggling
+ * between Include, Exclude, and Regex filter modes. Complements the
+ * FilterModeSelector dropdown with a segmented control form factor.
+ *
+ * Colors per Patterns Library §2.3:
+ *   I = --v-accent-primary        (blue)
+ *   E = --v-status-error          (red)
+ *   R = --v-accent-quaternary     (muted violet)
+ *
+ * Mode state is stored in viewFilterStore keyed by viewId.
+ *
+ * Implements US-108 (AC-1 through AC-7).
+ */
+
+import React, { useEffect } from 'react';
+import { t } from '../../lib/i18n';
+import type { FilterMode } from '../FilterSystem/types';
+import classes from './ModeSwitch.module.css';
+
+export interface ModeSwitchProps {
+  /** The currently selected mode. */
+  value: FilterMode;
+  /** Called when the user selects a different mode. */
+  onChange: (mode: FilterMode) => void;
+  /** When true, the Regex option is hidden (N/A for number/date/boolean columns). */
+  disableRegex?: boolean;
+  /** When true, the control is non-interactive. */
+  disabled?: boolean;
+  /** Accessible label for the segmented control group. */
+  'aria-label'?: string;
+}
+
+interface ModeOption {
+  mode: FilterMode;
+  labelKey: string;
+  shortKey: string;
+}
+
+const ALL_OPTIONS: ModeOption[] = [
+  { mode: 'include', labelKey: 'filter.mode.include', shortKey: 'filter.mode.include.short' },
+  { mode: 'exclude', labelKey: 'filter.mode.exclude', shortKey: 'filter.mode.exclude.short' },
+  { mode: 'regex',   labelKey: 'filter.mode.regex',   shortKey: 'filter.mode.regex.short' },
+];
+
+const MODE_ACTIVE_CLASS: Record<FilterMode, string> = {
+  include: classes.activeInclude,
+  exclude: classes.activeExclude,
+  regex:   classes.activeRegex,
+};
+
+export function ModeSwitch({
+  value,
+  onChange,
+  disableRegex = false,
+  disabled = false,
+  'aria-label': ariaLabel,
+}: ModeSwitchProps) {
+  const options = disableRegex
+    ? ALL_OPTIONS.filter((o) => o.mode !== 'regex')
+    : ALL_OPTIONS;
+
+  // Fallback: if regex is disabled but currently selected (e.g. from persisted state),
+  // reset to 'include' to avoid rendering with no active segment.
+  useEffect(() => {
+    if (disableRegex && value === 'regex') {
+      onChange('include');
+    }
+  }, [disableRegex, value, onChange]);
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel ?? t('filter.modeSwitch.ariaLabel')}
+      className={`${classes.root} ${disabled ? classes.disabled : ''}`}
+    >
+      {options.map(({ mode, labelKey, shortKey }) => {
+        const isActive = value === mode;
+        return (
+          <button
+            key={mode}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            disabled={disabled}
+            className={`${classes.segment} ${isActive ? `${classes.active} ${MODE_ACTIVE_CLASS[mode]}` : classes.inactive}`}
+            onClick={() => {
+              if (!disabled) onChange(mode);
+            }}
+            title={t(`filter.modeSwitch.${mode}.tooltip`)}
+          >
+            <span className={classes.short} aria-hidden="true">
+              {t(shortKey)}
+            </span>
+            <span className={classes.label}>{t(labelKey)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/workspace/src/components/ModeSwitch/__tests__/ModeSwitch.test.tsx
+++ b/packages/workspace/src/components/ModeSwitch/__tests__/ModeSwitch.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * ModeSwitch unit tests.
+ *
+ * Covers:
+ * - Renders all three mode segments by default
+ * - Hides regex segment when disableRegex is true
+ * - Falls back to include when disableRegex and value is regex
+ * - Active segment has aria-checked="true"
+ * - Inactive segments have aria-checked="false"
+ * - Clicking a segment calls onChange with the correct mode
+ * - Disabled state: clicks do not fire onChange
+ * - Disabled state: segments have disabled attribute
+ * - Custom aria-label is forwarded to the group
+ * - Uses role="radiogroup"
+ * - Tooltip shows descriptive text (not just mode name)
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TestProviders } from '../../../test-utils/providers';
+import { ModeSwitch } from '../ModeSwitch';
+import type { FilterMode } from '../../FilterSystem/types';
+
+function renderSwitch(
+  value: FilterMode = 'include',
+  onChange = vi.fn(),
+  props: Partial<React.ComponentProps<typeof ModeSwitch>> = {},
+) {
+  return render(
+    <ModeSwitch value={value} onChange={onChange} {...props} />,
+    { wrapper: TestProviders },
+  );
+}
+
+function getRadioByName(name: string) {
+  return screen.getAllByRole('radio').find((el) => el.textContent?.includes(name));
+}
+
+describe('ModeSwitch', () => {
+  it('renders three segments by default', () => {
+    renderSwitch();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('renders only two segments when disableRegex is true', () => {
+    renderSwitch('include', vi.fn(), { disableRegex: true });
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('calls onChange with include when disableRegex is true and value is regex', () => {
+    const onChange = vi.fn();
+    renderSwitch('regex', onChange, { disableRegex: true });
+    expect(onChange).toHaveBeenCalledWith('include');
+  });
+
+  it('marks the active segment with aria-checked="true"', () => {
+    renderSwitch('exclude');
+    const excludeBtn = getRadioByName('Exclude');
+    expect(excludeBtn?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('marks inactive segments with aria-checked="false"', () => {
+    renderSwitch('include');
+    const excludeBtn = getRadioByName('Exclude');
+    const regexBtn = getRadioByName('Regex');
+    expect(excludeBtn?.getAttribute('aria-checked')).toBe('false');
+    expect(regexBtn?.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('calls onChange with "exclude" when Exclude is clicked', () => {
+    const onChange = vi.fn();
+    renderSwitch('include', onChange);
+    fireEvent.click(getRadioByName('Exclude')!);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith('exclude');
+  });
+
+  it('calls onChange with "regex" when Regex is clicked', () => {
+    const onChange = vi.fn();
+    renderSwitch('include', onChange);
+    fireEvent.click(getRadioByName('Regex')!);
+    expect(onChange).toHaveBeenCalledWith('regex');
+  });
+
+  it('calls onChange with "include" when Include is clicked', () => {
+    const onChange = vi.fn();
+    renderSwitch('exclude', onChange);
+    fireEvent.click(getRadioByName('Include')!);
+    expect(onChange).toHaveBeenCalledWith('include');
+  });
+
+  it('does not call onChange when disabled and a segment is clicked', () => {
+    const onChange = vi.fn();
+    renderSwitch('include', onChange, { disabled: true });
+    fireEvent.click(getRadioByName('Exclude')!);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('sets disabled attribute on all segments when disabled', () => {
+    renderSwitch('include', vi.fn(), { disabled: true });
+    const buttons = screen.getAllByRole('radio');
+    buttons.forEach((btn) => {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    });
+  });
+
+  it('uses a custom aria-label on the radiogroup', () => {
+    renderSwitch('include', vi.fn(), { 'aria-label': 'Custom label' });
+    expect(screen.getByRole('radiogroup', { name: 'Custom label' })).toBeTruthy();
+  });
+
+  it('renders the container with role="radiogroup"', () => {
+    renderSwitch();
+    expect(screen.getByRole('radiogroup')).toBeTruthy();
+  });
+
+  it('renders segments with role="radio"', () => {
+    renderSwitch();
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+  });
+
+  it('renders short labels I, E, R', () => {
+    renderSwitch();
+    expect(screen.getByText('I')).toBeTruthy();
+    expect(screen.getByText('E')).toBeTruthy();
+    expect(screen.getByText('R')).toBeTruthy();
+  });
+
+  it('renders full mode labels Include, Exclude, Regex', () => {
+    renderSwitch();
+    expect(screen.getAllByText('Include').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Exclude').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Regex').length).toBeGreaterThan(0);
+  });
+
+  it('tooltips show descriptive text not just mode names', () => {
+    renderSwitch();
+    const includeBtn = getRadioByName('Include');
+    expect(includeBtn?.getAttribute('title')).toContain('rows');
+  });
+});

--- a/packages/workspace/src/components/ModeSwitch/index.ts
+++ b/packages/workspace/src/components/ModeSwitch/index.ts
@@ -1,0 +1,6 @@
+/**
+ * ModeSwitch barrel export.
+ */
+
+export { ModeSwitch } from './ModeSwitch';
+export type { ModeSwitchProps } from './ModeSwitch';

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -29,7 +29,7 @@ export { useSidebarStore } from './stores/sidebarStore';
 export { usePanelStore, openPanelByTypeId } from './stores/panelStore';
 export { useTrayStore } from './stores/trayStore';
 export { useViewStore } from './stores/viewStore';
-export { useViewFilterStore, useViewFilters } from './stores/viewFilterStore';
+export { useViewFilterStore, useViewFilters, useViewMode } from './stores/viewFilterStore';
 
 // Hooks
 export { usePanelPersistence, PANEL_LAYOUT_STORAGE_KEY } from './hooks/usePanelPersistence';
@@ -45,6 +45,10 @@ export type {
   PanelState,
   SerializedLayout,
 } from './types/panel';
+
+// ModeSwitch
+export { ModeSwitch } from './components/ModeSwitch';
+export type { ModeSwitchProps } from './components/ModeSwitch';
 
 // FilterSystem
 export {

--- a/packages/workspace/src/stores/viewFilterStore.ts
+++ b/packages/workspace/src/stores/viewFilterStore.ts
@@ -4,16 +4,30 @@
  * Stores filter state keyed by view ID, allowing each panel/view
  * to maintain independent filter state.
  *
- * Implements US-114 (AC-9, AC-10, AC-11).
+ * Also stores the active IER (Include/Exclude/Regex) mode per view,
+ * used by ModeSwitch and filter inputs to default new conditions to
+ * the currently selected mode.
+ *
+ * Implements US-114 (AC-9, AC-10, AC-11) and US-108 (AC-6, AC-7).
  */
 
 import { create } from 'zustand';
-import type { FilterState, FilterGroup } from '../components/FilterSystem/types';
+import type { FilterMode, FilterState, FilterGroup } from '../components/FilterSystem/types';
 import { countConditions } from '../components/FilterSystem/types';
+
+/** Default IER filter mode — new filters start in Include mode. */
+const DEFAULT_MODE: FilterMode = 'include';
 
 interface ViewFilterState {
   /** Filter state keyed by view ID. */
   filtersByView: Record<string, FilterState>;
+
+  /**
+   * Active IER mode keyed by view ID.
+   * Determines the default mode for new filter conditions (AC-6).
+   * Serializable as part of panel state (AC-7).
+   */
+  modeByView: Record<string, FilterMode>;
 
   /** Get the current filter state for a view. */
   getFilters: (viewId: string) => FilterState;
@@ -23,6 +37,12 @@ interface ViewFilterState {
 
   /** Clear all filters for a view. */
   clearFilters: (viewId: string) => void;
+
+  /** Get the active IER mode for a view. */
+  getMode: (viewId: string) => FilterMode;
+
+  /** Set the active IER mode for a view. */
+  setMode: (viewId: string, mode: FilterMode) => void;
 
   /** Clear all views' filter state. */
   clearAll: () => void;
@@ -35,6 +55,7 @@ const DEFAULT_FILTER_STATE: FilterState = {
 
 export const useViewFilterStore = create<ViewFilterState>()((set, get) => ({
   filtersByView: {},
+  modeByView: {},
 
   getFilters: (viewId) => {
     return get().filtersByView[viewId] ?? DEFAULT_FILTER_STATE;
@@ -58,8 +79,21 @@ export const useViewFilterStore = create<ViewFilterState>()((set, get) => ({
     }));
   },
 
+  getMode: (viewId) => {
+    return get().modeByView[viewId] ?? DEFAULT_MODE;
+  },
+
+  setMode: (viewId, mode) => {
+    set((prev) => ({
+      modeByView: {
+        ...prev.modeByView,
+        [viewId]: mode,
+      },
+    }));
+  },
+
   clearAll: () => {
-    set({ filtersByView: {} });
+    set({ filtersByView: {}, modeByView: {} });
   },
 }));
 
@@ -98,4 +132,27 @@ export function useViewFilters(viewId: string): {
     activeFilterCount,
     root: filterState.root,
   };
+}
+
+/**
+ * Convenience hook for a specific view's IER mode.
+ * Used by ModeSwitch and filter inputs.
+ *
+ * Returns the active mode and a setter.
+ * Default is 'include' when no mode has been set for the view.
+ *
+ * The mode is per-view (AC-6) and is part of serializable panel state (AC-7).
+ */
+export function useViewMode(viewId: string): {
+  mode: FilterMode;
+  setMode: (mode: FilterMode) => void;
+} {
+  const mode = useViewFilterStore((s) => s.modeByView[viewId] ?? DEFAULT_MODE);
+  const storeSetter = useViewFilterStore((s) => s.setMode);
+
+  function setMode(m: FilterMode) {
+    storeSetter(viewId, m);
+  }
+
+  return { mode, setMode };
 }


### PR DESCRIPTION
## Summary
- ModeSwitch segmented control (I/E/R) with ARIA radiogroup pattern
- Mode colors: I=--v-accent-primary, E=--v-status-error, R=--v-accent-quaternary
- viewFilterStore extended with per-view mode state
- disableRegex prop with automatic fallback to 'include'
- Descriptive tooltips on each mode button

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)