### PR TITLE
feat(workspace): view toolbar with save/reset and modified indicator [VASTU-1A-111]

### DIFF
--- a/packages/workspace/messages/en.json
+++ b/packages/workspace/messages/en.json
@@ -68,5 +68,30 @@
   "filter.builder.columnPlaceholder": "Select column...",
   "filter.dimension.noMatch": "No columns match",
   "filter.input.enum.noMatch": "No values found",
-  "filter.input.enum.noOptions": "No options"
+  "filter.input.enum.noOptions": "No options",
+
+  "view.toolbar.ariaLabel": "View toolbar",
+  "view.toolbar.viewNameAriaLabel": "View name",
+  "view.toolbar.modified": "Modified",
+  "view.toolbar.reset": "Reset",
+  "view.toolbar.resetAriaLabel": "Reset view to last saved state",
+  "view.toolbar.save": "Save",
+  "view.toolbar.saveAriaLabel": "Save current view",
+  "view.toolbar.share": "Share",
+  "view.toolbar.shareAriaLabel": "Share view",
+  "view.toolbar.more": "More options",
+  "view.toolbar.moreAriaLabel": "More view options",
+
+  "view.selector.ariaLabel": "Switch view",
+  "view.selector.searchPlaceholder": "Search views...",
+  "view.selector.searchAriaLabel": "Search views",
+  "view.selector.myViews": "MY VIEWS",
+  "view.selector.sharedWithMe": "SHARED WITH ME",
+  "view.selector.noResults": "No views found",
+  "view.selector.createNew": "Create new view",
+  "view.selector.rename": "Rename",
+  "view.selector.delete": "Delete",
+  "view.selector.deleteConfirm": "Delete this view? This action cannot be undone.",
+  "view.selector.entryMenuAriaLabel": "View options",
+  "view.selector.renameAriaLabel": "Rename view"
 }

--- a/packages/workspace/src/components/ViewToolbar/ViewSelector.module.css
+++ b/packages/workspace/src/components/ViewToolbar/ViewSelector.module.css
@@ -1,0 +1,122 @@
+/**
+ * ViewSelector dropdown styles.
+ * All colors via --v-* CSS custom properties.
+ */
+
+/* ================================================================
+ * Trigger button
+ * ================================================================ */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  border-radius: var(--v-radius-sm);
+  flex-shrink: 0;
+  cursor: pointer;
+  color: var(--v-text-secondary);
+}
+
+.trigger:hover {
+  background-color: var(--v-bg-tertiary);
+  color: var(--v-text-primary);
+}
+
+.chevron {
+  color: var(--v-text-tertiary);
+  flex-shrink: 0;
+}
+
+/* ================================================================
+ * Dropdown
+ * ================================================================ */
+.dropdown {
+  padding: var(--v-space-2);
+  background-color: var(--v-bg-elevated);
+  border: 1px solid var(--v-border-default);
+}
+
+.searchInput {
+  margin-bottom: 4px;
+}
+
+.sectionLabel {
+  padding: 4px var(--v-space-1) 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.emptyLabel {
+  padding: var(--v-space-2) var(--v-space-1);
+  text-align: center;
+  font-style: italic;
+}
+
+.divider {
+  margin: var(--v-space-1) 0;
+  border-color: var(--v-border-subtle);
+}
+
+.createButton {
+  color: var(--v-accent-primary) !important;
+  font-size: var(--v-text-sm) !important;
+  justify-content: flex-start;
+}
+
+.createButton:hover {
+  background-color: var(--v-accent-primary-light) !important;
+}
+
+/* ================================================================
+ * View entry row
+ * ================================================================ */
+.entry {
+  display: flex;
+  align-items: center;
+  gap: var(--v-space-1);
+  padding: 3px var(--v-space-1);
+  border-radius: var(--v-radius-sm);
+  min-height: 28px;
+}
+
+.entry:hover {
+  background-color: var(--v-bg-tertiary);
+}
+
+.entryActive {
+  background-color: var(--v-accent-primary-light);
+}
+
+.colorDot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.entryName {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--v-text-sm);
+  color: var(--v-text-primary);
+  font-family: var(--v-font-sans);
+  text-align: left;
+  padding: 0;
+}
+
+.entryMenu {
+  opacity: 0;
+  flex-shrink: 0;
+  color: var(--v-text-secondary) !important;
+}
+
+.entry:hover .entryMenu,
+.entry:focus-within .entryMenu {
+  opacity: 1;
+}
+
+.renameInput {
+  flex: 1;
+  min-width: 0;
+}

--- a/packages/workspace/src/components/ViewToolbar/ViewSelector.tsx
+++ b/packages/workspace/src/components/ViewToolbar/ViewSelector.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+/**
+ * ViewSelector — dropdown popover listing available views.
+ *
+ * Shows two sections:
+ *   - MY VIEWS: views owned by the current user
+ *   - SHARED WITH ME: views shared with the organization
+ *
+ * Each entry has: color dot · view name (TruncatedText) · ⋯ menu (rename, delete)
+ * Active view is highlighted.
+ *
+ * "+" Create new view action at the bottom.
+ *
+ * Implements US-111 AC-2, AC-3.
+ */
+
+import React from 'react';
+import {
+  Popover,
+  TextInput,
+  Text,
+  Stack,
+  UnstyledButton,
+  Menu,
+  ActionIcon,
+  Divider,
+  Button,
+} from '@mantine/core';
+import { IconChevronDown, IconDots, IconPlus } from '@tabler/icons-react';
+import { t } from '../../lib/i18n';
+import { TruncatedText } from '../TruncatedText';
+import type { View } from '@vastu/shared/types';
+import classes from './ViewSelector.module.css';
+
+export interface ViewSelectorProps {
+  /** Currently active view ID (null for unsaved). */
+  currentViewId: string | null;
+  /** Current user ID, used to split MY VIEWS vs SHARED WITH ME. */
+  currentUserId?: string;
+  /** All views accessible to the user. */
+  views: View[];
+  /** Called when user selects a view to load. */
+  onSelect: (id: string) => void;
+  /** Called when user clicks "+ Create new view". */
+  onCreate: () => void;
+  /** Called when user renames a view. */
+  onRename: (id: string, name: string) => void;
+  /** Called when user deletes a view. */
+  onDelete: (id: string) => void;
+}
+
+export function ViewSelector({
+  currentViewId,
+  currentUserId,
+  views,
+  onSelect,
+  onCreate,
+  onRename,
+  onDelete,
+}: ViewSelectorProps) {
+  const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+  const [renamingId, setRenamingId] = React.useState<string | null>(null);
+  const [renameValue, setRenameValue] = React.useState('');
+
+  const filtered = React.useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return views;
+    return views.filter((v) => v.name.toLowerCase().includes(q));
+  }, [views, search]);
+
+  const myViews = filtered.filter((v) => v.createdBy === currentUserId);
+  const sharedViews = filtered.filter((v) => v.isShared && v.createdBy !== currentUserId);
+
+  function handleSelect(id: string) {
+    onSelect(id);
+    setOpen(false);
+    setSearch('');
+  }
+
+  function handleRenameCommit(id: string) {
+    const trimmed = renameValue.trim();
+    if (trimmed) {
+      onRename(id, trimmed);
+    }
+    setRenamingId(null);
+    setRenameValue('');
+  }
+
+  function handleRenameCancel() {
+    setRenamingId(null);
+    setRenameValue('');
+  }
+
+  function startRename(view: View) {
+    setRenamingId(view.id);
+    setRenameValue(view.name);
+  }
+
+  const activeView = views.find((v) => v.id === currentViewId);
+
+  return (
+    <Popover
+      opened={open}
+      onChange={setOpen}
+      width={260}
+      position="bottom-start"
+      shadow="md"
+      withinPortal
+    >
+      <Popover.Target>
+        <UnstyledButton
+          className={classes.trigger}
+          onClick={() => setOpen((o) => !o)}
+          aria-label={t('view.selector.ariaLabel')}
+          aria-expanded={open}
+        >
+          {activeView?.colorDot && (
+            <span
+              className={classes.colorDot}
+              style={{ backgroundColor: activeView.colorDot }}
+              aria-hidden="true"
+            />
+          )}
+          <IconChevronDown size={12} className={classes.chevron} aria-hidden="true" />
+        </UnstyledButton>
+      </Popover.Target>
+
+      <Popover.Dropdown className={classes.dropdown}>
+        <Stack gap={4}>
+          {/* Search input */}
+          <TextInput
+            placeholder={t('view.selector.searchPlaceholder')}
+            value={search}
+            onChange={(e) => setSearch(e.currentTarget.value)}
+            size="xs"
+            className={classes.searchInput}
+            aria-label={t('view.selector.searchAriaLabel')}
+            autoFocus
+          />
+
+          {/* MY VIEWS section */}
+          {myViews.length > 0 && (
+            <>
+              <Text
+                size="xs"
+                fw={500}
+                c="var(--v-text-tertiary)"
+                className={classes.sectionLabel}
+              >
+                {t('view.selector.myViews')}
+              </Text>
+              {myViews.map((view) => (
+                <ViewEntry
+                  key={view.id}
+                  view={view}
+                  isActive={view.id === currentViewId}
+                  isRenaming={renamingId === view.id}
+                  renameValue={renameValue}
+                  onSelect={handleSelect}
+                  onStartRename={startRename}
+                  onRenameValueChange={setRenameValue}
+                  onRenameCommit={handleRenameCommit}
+                  onRenameCancel={handleRenameCancel}
+                  onDelete={onDelete}
+                />
+              ))}
+            </>
+          )}
+
+          {/* SHARED WITH ME section */}
+          {sharedViews.length > 0 && (
+            <>
+              {myViews.length > 0 && <Divider className={classes.divider} />}
+              <Text
+                size="xs"
+                fw={500}
+                c="var(--v-text-tertiary)"
+                className={classes.sectionLabel}
+              >
+                {t('view.selector.sharedWithMe')}
+              </Text>
+              {sharedViews.map((view) => (
+                <ViewEntry
+                  key={view.id}
+                  view={view}
+                  isActive={view.id === currentViewId}
+                  isRenaming={renamingId === view.id}
+                  renameValue={renameValue}
+                  onSelect={handleSelect}
+                  onStartRename={startRename}
+                  onRenameValueChange={setRenameValue}
+                  onRenameCommit={handleRenameCommit}
+                  onRenameCancel={handleRenameCancel}
+                  onDelete={onDelete}
+                />
+              ))}
+            </>
+          )}
+
+          {/* Empty state */}
+          {filtered.length === 0 && (
+            <Text size="sm" c="var(--v-text-tertiary)" className={classes.emptyLabel}>
+              {t('view.selector.noResults')}
+            </Text>
+          )}
+
+          <Divider className={classes.divider} />
+
+          {/* Create new view */}
+          <Button
+            variant="subtle"
+            size="xs"
+            leftSection={<IconPlus size={12} />}
+            onClick={() => {
+              onCreate();
+              setOpen(false);
+            }}
+            className={classes.createButton}
+          >
+            {t('view.selector.createNew')}
+          </Button>
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
+/* ================================================================
+ * Internal: single view entry row
+ * ================================================================ */
+
+interface ViewEntryProps {
+  view: View;
+  isActive: boolean;
+  isRenaming: boolean;
+  renameValue: string;
+  onSelect: (id: string) => void;
+  onStartRename: (view: View) => void;
+  onRenameValueChange: (value: string) => void;
+  onRenameCommit: (id: string) => void;
+  onRenameCancel: () => void;
+  onDelete: (id: string) => void;
+}
+
+function ViewEntry({
+  view,
+  isActive,
+  isRenaming,
+  renameValue,
+  onSelect,
+  onStartRename,
+  onRenameValueChange,
+  onRenameCommit,
+  onRenameCancel,
+  onDelete,
+}: ViewEntryProps) {
+  return (
+    <div
+      className={`${classes.entry} ${isActive ? classes.entryActive : ''}`}
+      data-active={isActive}
+    >
+      {/* Color dot */}
+      <span
+        className={classes.colorDot}
+        style={{ backgroundColor: view.colorDot ?? 'var(--v-text-tertiary)' }}
+        aria-hidden="true"
+      />
+
+      {/* Name — either inline input or truncated label */}
+      {isRenaming ? (
+        <TextInput
+          value={renameValue}
+          onChange={(e) => onRenameValueChange(e.currentTarget.value)}
+          onBlur={() => onRenameCommit(view.id)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onRenameCommit(view.id);
+            if (e.key === 'Escape') onRenameCancel();
+          }}
+          size="xs"
+          className={classes.renameInput}
+          aria-label={t('view.selector.renameAriaLabel')}
+          autoFocus
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : (
+        <UnstyledButton className={classes.entryName} onClick={() => onSelect(view.id)}>
+          <TruncatedText maxWidth={160}>{view.name}</TruncatedText>
+        </UnstyledButton>
+      )}
+
+      {/* ⋯ context menu */}
+      {!isRenaming && (
+        <Menu position="right-start" shadow="sm" withinPortal>
+          <Menu.Target>
+            <ActionIcon
+              size="xs"
+              variant="subtle"
+              className={classes.entryMenu}
+              aria-label={t('view.selector.entryMenuAriaLabel')}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <IconDots size={12} />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item onClick={() => onStartRename(view)}>
+              {t('view.selector.rename')}
+            </Menu.Item>
+            <Menu.Item
+              color="red"
+              onClick={() => {
+                if (window.confirm(t('view.selector.deleteConfirm'))) {
+                  onDelete(view.id);
+                }
+              }}
+            >
+              {t('view.selector.delete')}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      )}
+    </div>
+  );
+}

--- a/packages/workspace/src/components/ViewToolbar/ViewToolbar.module.css
+++ b/packages/workspace/src/components/ViewToolbar/ViewToolbar.module.css
@@ -1,0 +1,163 @@
+/**
+ * ViewToolbar styles.
+ *
+ * Horizontal toolbar rendered below the Dockview tab bar in every panel.
+ * Shows current view name, modified indicator, Save / Reset controls,
+ * and a view-selector dropdown.
+ *
+ * All colors and spacing via --v-* CSS custom properties only.
+ */
+
+/* ================================================================
+ * Toolbar root
+ * ================================================================ */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 var(--v-space-3);
+  background-color: var(--v-bg-secondary);
+  border-bottom: 1px solid var(--v-border-default);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+/* ================================================================
+ * Left section — view selector + view name
+ * ================================================================ */
+.left {
+  display: flex;
+  align-items: center;
+  gap: var(--v-space-2);
+  flex: 1;
+  min-width: 0;
+}
+
+/* ================================================================
+ * Right section — controls
+ * ================================================================ */
+.right {
+  display: flex;
+  align-items: center;
+  gap: var(--v-space-2);
+  flex-shrink: 0;
+  margin-left: var(--v-space-3);
+}
+
+/* ================================================================
+ * View name (inline editable)
+ * ================================================================ */
+.viewNameWrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--v-space-1);
+  min-width: 0;
+  max-width: 280px;
+  cursor: pointer;
+}
+
+.viewNameInput {
+  border: none;
+  background: transparent;
+  font-family: var(--v-font-sans);
+  font-size: var(--v-text-sm);
+  font-weight: var(--v-font-medium);
+  color: var(--v-text-primary);
+  padding: 2px 4px;
+  border-radius: var(--v-radius-sm);
+  outline: none;
+  width: 100%;
+  min-width: 60px;
+  cursor: pointer;
+}
+
+.viewNameInput:focus {
+  background-color: var(--v-bg-primary);
+  border: 1px solid var(--v-border-strong);
+  cursor: text;
+}
+
+.viewNameInput:hover:not(:focus) {
+  background-color: var(--v-bg-tertiary);
+}
+
+/* ================================================================
+ * Modified indicator — goldenrod dot + "Modified" label + Reset link
+ * ================================================================ */
+.modifiedIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--v-space-1);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.modifiedDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--v-accent-tertiary);
+  flex-shrink: 0;
+}
+
+.modifiedLabel {
+  font-family: var(--v-font-sans);
+  font-size: var(--v-text-xs);
+  font-weight: var(--v-font-regular);
+  color: var(--v-accent-tertiary);
+  white-space: nowrap;
+}
+
+.resetLink {
+  font-family: var(--v-font-sans);
+  font-size: var(--v-text-xs);
+  font-weight: var(--v-font-regular);
+  color: var(--v-text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.resetLink:hover {
+  color: var(--v-text-primary);
+}
+
+/* ================================================================
+ * Save button state overrides
+ * ================================================================ */
+
+/* When modified: primary blue */
+.saveButtonModified {
+  background-color: var(--v-accent-primary) !important;
+  color: var(--v-text-inverted) !important;
+  border-color: var(--v-accent-primary) !important;
+}
+
+.saveButtonModified:hover {
+  background-color: var(--v-accent-primary-hover) !important;
+  border-color: var(--v-accent-primary-hover) !important;
+}
+
+/* When clean: dimmed */
+.saveButtonClean {
+  opacity: 0.45;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+/* ================================================================
+ * Separator between left and right sections
+ * ================================================================ */
+.separator {
+  width: 1px;
+  height: 18px;
+  background-color: var(--v-border-default);
+  flex-shrink: 0;
+  margin: 0 var(--v-space-2);
+}

--- a/packages/workspace/src/components/ViewToolbar/ViewToolbar.tsx
+++ b/packages/workspace/src/components/ViewToolbar/ViewToolbar.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+/**
+ * ViewToolbar — per-panel toolbar for view management.
+ *
+ * Rendered between the Dockview tab bar and the panel content in every panel.
+ *
+ * Layout:
+ *   [ ViewSelector ↓ ] [ View name (inline editable) ] [ ● Modified  Reset ] | [ Save ]
+ *
+ * State:
+ * - isModified (from viewStore): shows goldenrod dot + "Modified" + "Reset" link
+ * - Save button: primary blue when modified, dimmed when clean
+ * - View name: editable inline; commits on blur/Enter
+ *
+ * Keyboard:
+ * - ⌘S saves the view (registered at toolbar level — global shortcut wired in US-117)
+ *
+ * Implements US-111 (AC-1, AC-2, AC-3, AC-4, AC-5, AC-9).
+ *
+ * Note: Share (AC-6), Export (AC-7), and overflow (AC-8) are scaffolded as
+ * disabled button slots — implementation comes with the relevant data features.
+ */
+
+import React from 'react';
+import { Button, ActionIcon, Tooltip } from '@mantine/core';
+import { IconShare, IconDots } from '@tabler/icons-react';
+import { t } from '../../lib/i18n';
+import { useViewStore } from '../../stores/viewStore';
+import { ViewSelector } from './ViewSelector';
+import type { View } from '@vastu/shared/types';
+import classes from './ViewToolbar.module.css';
+
+export interface ViewToolbarProps {
+  /**
+   * Page ID — required by saveView to associate the view with a page.
+   */
+  pageId: string;
+  /**
+   * Available views to display in the selector.
+   * The consumer provides these (typically via TanStack Query).
+   */
+  views?: View[];
+  /**
+   * Current user's ID — used to split MY VIEWS / SHARED WITH ME.
+   */
+  currentUserId?: string;
+  /**
+   * Called when the user picks a different view from the selector.
+   * The toolbar will call `loadView(id)` automatically; this callback
+   * allows the parent to react (e.g., re-run queries).
+   */
+  onViewChange?: (id: string) => void;
+  /**
+   * Called when the user clicks "+ Create new view".
+   * Parent is responsible for collecting a name and calling `saveView`.
+   */
+  onCreateView?: () => void;
+  /**
+   * Called when user renames a view in the selector dropdown.
+   */
+  onRenameView?: (id: string, name: string) => void;
+  /**
+   * Called when user deletes a view in the selector dropdown.
+   */
+  onDeleteView?: (id: string) => void;
+}
+
+/**
+ * Default view name when no view is loaded.
+ * This is what appears in the toolbar before the user saves a named view.
+ */
+const DEFAULT_VIEW_NAME = 'Default view';
+
+export function ViewToolbar({
+  pageId,
+  views = [],
+  currentUserId,
+  onViewChange,
+  onCreateView,
+  onRenameView,
+  onDeleteView,
+}: ViewToolbarProps) {
+  const { currentViewId, isModified, saveView, loadView, resetView, setViewState } = useViewStore();
+
+  // Ref to the inline name input — used to allow Cmd+S from within it.
+  const nameInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Derive the current view name from the views list (or fall back to default).
+  const currentView = views.find((v) => v.id === currentViewId) ?? null;
+  const [localName, setLocalName] = React.useState<string>(
+    currentView?.name ?? DEFAULT_VIEW_NAME,
+  );
+  // Track whether the name input is focused (to gate commit logic).
+  const [isEditingName, setIsEditingName] = React.useState(false);
+
+  // Keep localName in sync when the active view changes from outside.
+  React.useEffect(() => {
+    if (!isEditingName) {
+      setLocalName(currentView?.name ?? DEFAULT_VIEW_NAME);
+    }
+  }, [currentView?.name, isEditingName]);
+
+  const modified = isModified();
+
+  // ------------------------------------------------------------------
+  // Save
+  // ------------------------------------------------------------------
+  async function handleSave() {
+    if (!modified) return;
+    try {
+      await saveView(localName, pageId);
+    } catch {
+      // Error handling is intentionally minimal at toolbar level.
+      // Consumers can wrap in an error boundary or show a global toast.
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Reset
+  // ------------------------------------------------------------------
+  function handleReset() {
+    resetView();
+  }
+
+  // ------------------------------------------------------------------
+  // Inline name editing
+  // ------------------------------------------------------------------
+  function handleNameKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur();
+    }
+    if (e.key === 'Escape') {
+      // Revert to saved name on Escape.
+      setLocalName(currentView?.name ?? DEFAULT_VIEW_NAME);
+      setIsEditingName(false);
+      e.currentTarget.blur();
+    }
+  }
+
+  function handleNameBlur() {
+    setIsEditingName(false);
+    const trimmed = localName.trim();
+    if (!trimmed) {
+      setLocalName(currentView?.name ?? DEFAULT_VIEW_NAME);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // ViewSelector handlers
+  // ------------------------------------------------------------------
+  async function handleViewSelect(id: string) {
+    try {
+      await loadView(id);
+      onViewChange?.(id);
+    } catch {
+      // Silent — parent may surface an error toast.
+    }
+  }
+
+  function handleCreateView() {
+    // Start from a fresh default state — clears currentViewId and savedState
+    // so the toolbar shows "Default view" and the save button treats it as new.
+    setViewState(
+      {
+        filters: null,
+        sort: [],
+        columns: [],
+        pagination: { page: 1, pageSize: 25 },
+        scrollPosition: { x: 0, y: 0 },
+      },
+    );
+    onCreateView?.();
+  }
+
+  function handleRenameView(id: string, name: string) {
+    onRenameView?.(id, name);
+  }
+
+  function handleDeleteView(id: string) {
+    onDeleteView?.(id);
+  }
+
+  // ------------------------------------------------------------------
+  // Keyboard shortcut: ⌘S saves the view
+  // ------------------------------------------------------------------
+  React.useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        // Always prevent the browser's native "Save page" dialog for Cmd+S.
+        e.preventDefault();
+        // Allow Cmd+S from the toolbar's own name input; block from all other
+        // input elements (e.g., global search, form fields in other panels).
+        const active = document.activeElement;
+        const isOtherInput =
+          (active instanceof HTMLInputElement && active !== nameInputRef.current) ||
+          active instanceof HTMLTextAreaElement ||
+          active instanceof HTMLSelectElement;
+        if (!isOtherInput) {
+          void handleSave();
+        }
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modified, localName, pageId]);
+
+  return (
+    <div
+      className={classes.toolbar}
+      role="toolbar"
+      aria-label={t('view.toolbar.ariaLabel')}
+    >
+      {/* Left section */}
+      <div className={classes.left}>
+        {/* View selector dropdown trigger */}
+        <ViewSelector
+          currentViewId={currentViewId}
+          currentUserId={currentUserId}
+          views={views}
+          onSelect={handleViewSelect}
+          onCreate={handleCreateView}
+          onRename={handleRenameView}
+          onDelete={handleDeleteView}
+        />
+
+        {/* Inline editable view name */}
+        <div className={classes.viewNameWrapper}>
+          <input
+            ref={nameInputRef}
+            type="text"
+            className={classes.viewNameInput}
+            value={localName}
+            aria-label={t('view.toolbar.viewNameAriaLabel')}
+            onChange={(e) => setLocalName(e.currentTarget.value)}
+            onFocus={() => setIsEditingName(true)}
+            onBlur={handleNameBlur}
+            onKeyDown={handleNameKeyDown}
+            // Prevent truncation overflow from the input itself — TruncatedText
+            // handles the read-only presentation; input handles editing.
+          />
+        </div>
+
+        {/* Modified indicator */}
+        {modified && (
+          <div className={classes.modifiedIndicator} data-testid="modified-indicator">
+            <span className={classes.modifiedDot} aria-hidden="true" />
+            <span className={classes.modifiedLabel}>{t('view.toolbar.modified')}</span>
+            <button
+              type="button"
+              className={classes.resetLink}
+              onClick={handleReset}
+              aria-label={t('view.toolbar.resetAriaLabel')}
+            >
+              {t('view.toolbar.reset')}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Separator */}
+      <div className={classes.separator} aria-hidden="true" />
+
+      {/* Right section */}
+      <div className={classes.right}>
+        {/* Save button */}
+        <Button
+          size="xs"
+          className={modified ? classes.saveButtonModified : classes.saveButtonClean}
+          onClick={handleSave}
+          disabled={!modified}
+          aria-label={t('view.toolbar.saveAriaLabel')}
+          aria-disabled={!modified}
+          data-testid="save-button"
+        >
+          {t('view.toolbar.save')}
+        </Button>
+
+        {/* Share — placeholder (AC-6, implemented with data features) */}
+        <Tooltip label={t('view.toolbar.share')}>
+          <ActionIcon
+            size="sm"
+            variant="subtle"
+            aria-label={t('view.toolbar.shareAriaLabel')}
+            disabled
+            data-testid="share-button"
+          >
+            <IconShare size={14} />
+          </ActionIcon>
+        </Tooltip>
+
+        {/* Overflow — placeholder (AC-8, implemented with data features) */}
+        <Tooltip label={t('view.toolbar.more')}>
+          <ActionIcon
+            size="sm"
+            variant="subtle"
+            aria-label={t('view.toolbar.moreAriaLabel')}
+            disabled
+            data-testid="overflow-button"
+          >
+            <IconDots size={14} />
+          </ActionIcon>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/packages/workspace/src/components/ViewToolbar/__tests__/ViewToolbar.test.tsx
+++ b/packages/workspace/src/components/ViewToolbar/__tests__/ViewToolbar.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * ViewToolbar component tests.
+ *
+ * Covers:
+ * - Renders toolbar with role="toolbar"
+ * - Renders view name input
+ * - Save button present and disabled when view is unmodified
+ * - Save button enabled and styled when view is modified
+ * - Modified indicator (dot + label + Reset button) visible only when modified
+ * - Reset button calls resetView
+ * - Inline view name editing: blur commits, Escape reverts
+ * - ViewSelector trigger renders
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TestProviders } from '../../../test-utils/providers';
+import { ViewToolbar } from '../ViewToolbar';
+import { useViewStore } from '../../../stores/viewStore';
+import type { View } from '@vastu/shared/types';
+
+// Minimal View fixture
+const mockView: View = {
+  id: 'view-1',
+  name: 'My Test View',
+  pageId: 'page-1',
+  stateJson: {
+    filters: null,
+    sort: [],
+    columns: [],
+    pagination: { page: 1, pageSize: 25 },
+    scrollPosition: { x: 0, y: 0 },
+  },
+  createdBy: 'user-1',
+  isShared: false,
+  colorDot: '#2378CB',
+  organizationId: 'org-1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+};
+
+function renderToolbar(props?: Partial<React.ComponentProps<typeof ViewToolbar>>) {
+  return render(
+    <ViewToolbar pageId="page-1" {...props} />,
+    { wrapper: TestProviders },
+  );
+}
+
+describe('ViewToolbar', () => {
+  beforeEach(() => {
+    // Reset viewStore to a clean state before each test.
+    useViewStore.setState({
+      currentViewId: null,
+      savedState: null,
+      currentState: {
+        filters: null,
+        sort: [],
+        columns: [],
+        pagination: { page: 1, pageSize: 25 },
+        scrollPosition: { x: 0, y: 0 },
+      },
+    });
+    // Only clear call history, not implementations — restoreAllMocks would
+    // undo the window.matchMedia polyfill set in setup.ts and break Mantine hooks.
+    vi.clearAllMocks();
+  });
+
+  // ----------------------------------------------------------------
+  // Structure
+  // ----------------------------------------------------------------
+
+  it('renders a toolbar landmark', () => {
+    renderToolbar();
+    expect(screen.getByRole('toolbar', { name: /view toolbar/i })).toBeTruthy();
+  });
+
+  it('renders the view name input', () => {
+    renderToolbar();
+    expect(screen.getByRole('textbox', { name: /view name/i })).toBeTruthy();
+  });
+
+  it('renders the save button', () => {
+    renderToolbar();
+    expect(screen.getByTestId('save-button')).toBeTruthy();
+  });
+
+  it('renders the share button', () => {
+    renderToolbar();
+    expect(screen.getByTestId('share-button')).toBeTruthy();
+  });
+
+  it('renders the overflow button', () => {
+    renderToolbar();
+    expect(screen.getByTestId('overflow-button')).toBeTruthy();
+  });
+
+  // ----------------------------------------------------------------
+  // Modified state
+  // ----------------------------------------------------------------
+
+  it('does not show modified indicator when view is clean', () => {
+    // No savedState → isModified returns false
+    renderToolbar();
+    expect(screen.queryByTestId('modified-indicator')).toBeNull();
+  });
+
+  it('save button is disabled when view is clean', () => {
+    renderToolbar();
+    const saveBtn = screen.getByTestId('save-button');
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it('shows modified indicator when view state differs from saved', () => {
+    // Set a saved state, then mutate the current state to make it modified.
+    const savedState = {
+      filters: null,
+      sort: [],
+      columns: [],
+      pagination: { page: 1, pageSize: 25 },
+      scrollPosition: { x: 0, y: 0 },
+    };
+    useViewStore.setState({
+      currentViewId: 'view-1',
+      savedState,
+      currentState: {
+        ...savedState,
+        pagination: { page: 2, pageSize: 25 },
+      },
+    });
+
+    renderToolbar({ views: [mockView] });
+    expect(screen.getByTestId('modified-indicator')).toBeTruthy();
+    expect(screen.getByText('Modified')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /reset view/i })).toBeTruthy();
+  });
+
+  it('save button is enabled when view is modified', () => {
+    const savedState = {
+      filters: null,
+      sort: [],
+      columns: [],
+      pagination: { page: 1, pageSize: 25 },
+      scrollPosition: { x: 0, y: 0 },
+    };
+    useViewStore.setState({
+      currentViewId: 'view-1',
+      savedState,
+      currentState: {
+        ...savedState,
+        pagination: { page: 2, pageSize: 25 },
+      },
+    });
+
+    renderToolbar({ views: [mockView] });
+    const saveBtn = screen.getByTestId('save-button');
+    expect(saveBtn).not.toBeDisabled();
+  });
+
+  // ----------------------------------------------------------------
+  // Reset action
+  // ----------------------------------------------------------------
+
+  it('clicking Reset calls resetView and removes modified indicator', () => {
+    const savedState = {
+      filters: null,
+      sort: [],
+      columns: [],
+      pagination: { page: 1, pageSize: 25 },
+      scrollPosition: { x: 0, y: 0 },
+    };
+    useViewStore.setState({
+      currentViewId: 'view-1',
+      savedState,
+      currentState: {
+        ...savedState,
+        pagination: { page: 3, pageSize: 25 },
+      },
+    });
+
+    renderToolbar({ views: [mockView] });
+    const resetBtn = screen.getByRole('button', { name: /reset view/i });
+    fireEvent.click(resetBtn);
+
+    // After reset the indicator should disappear.
+    expect(screen.queryByTestId('modified-indicator')).toBeNull();
+  });
+
+  // ----------------------------------------------------------------
+  // View name editing
+  // ----------------------------------------------------------------
+
+  it('shows the active view name when a view is loaded', () => {
+    useViewStore.setState({
+      currentViewId: mockView.id,
+      savedState: mockView.stateJson,
+      currentState: mockView.stateJson,
+    });
+    renderToolbar({ views: [mockView] });
+    const input = screen.getByRole('textbox', { name: /view name/i }) as HTMLInputElement;
+    expect(input.value).toBe('My Test View');
+  });
+
+  it('shows default label when no view is loaded', () => {
+    renderToolbar();
+    const input = screen.getByRole('textbox', { name: /view name/i }) as HTMLInputElement;
+    expect(input.value).toBe('Default view');
+  });
+
+  it('updates local name when user types in the name input', () => {
+    renderToolbar();
+    const input = screen.getByRole('textbox', { name: /view name/i }) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'My New View' } });
+    expect(input.value).toBe('My New View');
+  });
+
+  it('pressing Escape reverts the name to the previous value', () => {
+    useViewStore.setState({
+      currentViewId: mockView.id,
+      savedState: mockView.stateJson,
+      currentState: mockView.stateJson,
+    });
+    renderToolbar({ views: [mockView] });
+    const input = screen.getByRole('textbox', { name: /view name/i }) as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'Typo Name' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(input.value).toBe('My Test View');
+  });
+
+  it('pressing Enter commits the name (blurs input)', () => {
+    renderToolbar();
+    const input = screen.getByRole('textbox', { name: /view name/i }) as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'New Name' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    // After Enter the value should be committed (not reverted).
+    expect(input.value).toBe('New Name');
+  });
+
+  // ----------------------------------------------------------------
+  // Save integration
+  // ----------------------------------------------------------------
+
+  it('calls saveView when Save button is clicked while modified', async () => {
+    const savedState = {
+      filters: null,
+      sort: [],
+      columns: [],
+      pagination: { page: 1, pageSize: 25 },
+      scrollPosition: { x: 0, y: 0 },
+    };
+    useViewStore.setState({
+      currentViewId: 'view-1',
+      savedState,
+      currentState: {
+        ...savedState,
+        pagination: { page: 2, pageSize: 25 },
+      },
+    });
+
+    // Mock fetch so saveView doesn't throw.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'view-1' }),
+      }),
+    );
+
+    renderToolbar({ views: [mockView] });
+    const saveBtn = screen.getByTestId('save-button');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalled();
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // ViewSelector present
+  // ----------------------------------------------------------------
+
+  it('renders the view selector trigger', () => {
+    renderToolbar();
+    expect(screen.getByRole('button', { name: /switch view/i })).toBeTruthy();
+  });
+});

--- a/packages/workspace/src/components/ViewToolbar/index.ts
+++ b/packages/workspace/src/components/ViewToolbar/index.ts
@@ -1,0 +1,14 @@
+/**
+ * ViewToolbar public API.
+ *
+ * ViewToolbar — view name + modified indicator + save/reset controls + view selector.
+ * ViewSelector — dropdown listing MY VIEWS / SHARED WITH ME with ⋯ menus.
+ *
+ * Implemented in US-111.
+ */
+
+export { ViewToolbar } from './ViewToolbar';
+export type { ViewToolbarProps } from './ViewToolbar';
+
+export { ViewSelector } from './ViewSelector';
+export type { ViewSelectorProps } from './ViewSelector';

--- a/packages/workspace/src/components/WorkspaceShell.tsx
+++ b/packages/workspace/src/components/WorkspaceShell.tsx
@@ -23,6 +23,7 @@ import { defineAbilitiesFor, type AppAbility } from '@vastu/shared/permissions';
 import { useSidebarStore } from '../stores/sidebarStore';
 import { DockviewHost } from './DockviewHost/DockviewHost';
 import { SidebarNav } from './SidebarNav';
+import { ViewToolbar } from './ViewToolbar';
 import classes from './WorkspaceShell.module.css';
 
 const SIDEBAR_COLLAPSED_WIDTH = 48;
@@ -44,6 +45,17 @@ export interface WorkspaceShellProps {
    * If omitted, a no-permissions ability is used (hides ADMIN section).
    */
   ability?: AppAbility;
+  /**
+   * Page ID for the currently active panel.
+   * Forwarded to ViewToolbar so it can associate saved views with a page.
+   * When not provided, ViewToolbar is not rendered (e.g., during initial load).
+   */
+  activePageId?: string;
+  /**
+   * Current user's ID — forwarded to ViewToolbar / ViewSelector for
+   * splitting MY VIEWS vs SHARED WITH ME.
+   */
+  currentUserId?: string;
 }
 
 /** Fallback no-permissions ability when none is provided. */
@@ -65,7 +77,13 @@ const DEFAULT_TRANSLATIONS = {
   noResults: 'No pages found',
 };
 
-export function WorkspaceShell({ children, user, ability }: WorkspaceShellProps) {
+export function WorkspaceShell({
+  children,
+  user,
+  ability,
+  activePageId,
+  currentUserId,
+}: WorkspaceShellProps) {
   const collapsed = useSidebarStore((state) => state.collapsed);
 
   const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_EXPANDED_WIDTH;
@@ -96,6 +114,11 @@ export function WorkspaceShell({ children, user, ability }: WorkspaceShellProps)
       </aside>
 
       <main className={classes.main} id="workspace-main">
+        {/* ViewToolbar sits between the sidebar and the Dockview panel area.
+            Always rendered; shows "Default view" when no page is active.
+            Falls back to an empty string pageId (no save call will be made
+            while the view is unmodified). */}
+        <ViewToolbar pageId={activePageId ?? ''} currentUserId={currentUserId} />
         <DockviewHost />
         {children}
       </main>

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -12,6 +12,8 @@ export { PanelTab } from './components/DockviewHost/PanelTab';
 export { DropIndicator } from './components/DockviewHost/DropIndicator';
 export { TruncatedText } from './components/TruncatedText';
 export { SidebarNav } from './components/SidebarNav';
+export { ViewToolbar, ViewSelector } from './components/ViewToolbar';
+export type { ViewToolbarProps, ViewSelectorProps } from './components/ViewToolbar';
 export type { WorkspaceUser, WorkspaceShellProps } from './components/WorkspaceShell';
 
 // Panel registry and built-in panels


### PR DESCRIPTION
## Summary
- ViewToolbar: view name (editable inline), save/reset, modified indicator (goldenrod dot)
- ViewSelector: dropdown with MY VIEWS / SHARED sections, search, color dots, rename/delete
- Delete requires confirmation dialog
- Cmd+S keyboard shortcut (works from toolbar name input)
- Always renders (no conditional on activePageId)
- Integrated into WorkspaceShell

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)