### PR TITLE
test(workspace): context menu ARIA and TruncatedText verification [VASTU-1B-123]

### DIFF
--- a/packages/workspace/src/components/ContextMenu/__tests__/ContextMenu.test.tsx
+++ b/packages/workspace/src/components/ContextMenu/__tests__/ContextMenu.test.tsx
@@ -68,6 +68,22 @@ describe('ContextMenu', () => {
     expect(screen.getByRole('menu')).toBeTruthy();
   });
 
+  it('menu container has role="menu" and tabIndex={-1} for ARIA compliance (#139)', () => {
+    renderContextMenu();
+    rightClick(screen.getByText('cell content'));
+    const menu = screen.getByRole('menu');
+    expect(menu.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('menu item label is wrapped in TruncatedText (#140)', () => {
+    renderContextMenu();
+    rightClick(screen.getByText('cell content'));
+    const label = screen.getByText('Copy');
+    // TruncatedText renders a <span> with a title attribute matching the text
+    expect(label.tagName).toBe('SPAN');
+    expect(label.getAttribute('title')).toBe('Copy');
+  });
+
   it('does NOT open the menu when right-clicking outside [data-context]', () => {
     renderContextMenu();
     const noCtx = screen.getByText('no context');


### PR DESCRIPTION
## Summary
- Verified `role="menu"` and `tabIndex={-1}` already present on ContextMenu container
- Verified `TruncatedText` already wraps labels in ContextMenuItem
- Added explicit test assertions to prevent regressions

Closes #139, #140, #169

## Test plan
- [x] New test: menu container has `role="menu"` and `tabIndex={-1}`
- [x] New test: menu item label is wrapped in `TruncatedText`
- [x] All 34 ContextMenu tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)