### PR TITLE
fix(workspace): address PR #261 review findings [VASTU-1B-120]

### DIFF
--- a/packages/workspace/src/components/DockviewHost/PanelTab.tsx
+++ b/packages/workspace/src/components/DockviewHost/PanelTab.tsx
@@ -59,7 +59,11 @@ export function PanelTab({ api }: IDockviewPanelHeaderProps) {
       <TruncatedText className={classes.title} maxWidth={160}>
         {title}
       </TruncatedText>
-      {/* ModeSwitch renders null when user only has Editor access (no builder/admin) */}
+      {/* ModeSwitch renders null when user only has Editor access (no builder/admin).
+          TODO(VASTU-1B-INFRA): wire ephemeralEnabled from panel config/page metadata
+          once the template infrastructure provides page config. Until then,
+          ephemeralEnabled defaults to false, so the Workflow segment is hidden for
+          all panels regardless of user role. */}
       <ModeSwitch panelId={api.id} />
       <button
         type="button"

--- a/packages/workspace/src/components/ModeSwitch/ModeSwitch.tsx
+++ b/packages/workspace/src/components/ModeSwitch/ModeSwitch.tsx
@@ -28,7 +28,7 @@
  * Implements US-120 (AC-2 through AC-8).
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { AppAbility } from '@vastu/shared/permissions';
 import { t } from '../../lib/i18n';
 import { useAbility } from '../../providers/AbilityContext';
@@ -94,6 +94,22 @@ export function ModeSwitch({ panelId, ability: abilityProp, ephemeralEnabled = f
     if (mode === 'workflow') return canUseWorkflow;
     return true; // editor is always visible
   });
+
+  const visibleModes = new Set<PanelMode>(visibleSegments.map(({ mode }) => mode));
+
+  // Reset stale mode: if the stored mode is no longer in the visible set
+  // (e.g., user's permissions changed to viewer-only or ephemeralEnabled flipped
+  // to false after Workflow was selected), fall back to 'editor' so the panel
+  // is never stuck in an inaccessible mode.
+  useEffect(() => {
+    if (!visibleModes.has(currentMode)) {
+      setPanelMode(panelId, 'editor');
+    }
+    // visibleModes is derived from ability and ephemeralEnabled — including it
+    // directly would cause referential instability on every render, so we depend
+    // on the stable primitives that drive it instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canUseBuilder, canUseWorkflow, currentMode, panelId, setPanelMode]);
 
   // If only Editor is available there is nothing to switch between — render nothing.
   if (visibleSegments.length <= 1) {

--- a/packages/workspace/src/components/ModeSwitch/__tests__/ModeSwitch.test.tsx
+++ b/packages/workspace/src/components/ModeSwitch/__tests__/ModeSwitch.test.tsx
@@ -22,7 +22,7 @@
 
 import React from 'react';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { defineAbilitiesFor, type AppAbility } from '@vastu/shared/permissions';
 import { TestProviders } from '../../../test-utils/providers';
 import { ModeSwitch } from '../ModeSwitch';
@@ -164,6 +164,58 @@ describe('ModeSwitch — serialization round-trip', () => {
 
     expect(screen.getByRole('radio', { name: /builder/i }).getAttribute('aria-checked')).toBe('true');
     expect(screen.getByRole('radio', { name: /editor/i }).getAttribute('aria-checked')).toBe('false');
+  });
+});
+
+// ---- Stale mode reset -------------------------------------------------------
+
+describe('ModeSwitch — stale mode reset', () => {
+  it('resets builder mode to editor when user ability changes to viewer-only', () => {
+    // Simulate a panel that previously stored 'builder' mode (e.g. from localStorage).
+    usePanelStore.setState({ panelModes: { 'panel-1': 'builder' } });
+
+    // Re-render with viewer ability (builder segment is hidden).
+    // The useEffect should fire and reset the stored mode back to 'editor'.
+    const { rerender } = render(
+      <ModeSwitch panelId="panel-1" ability={builderAbility} />,
+      { wrapper: TestProviders },
+    );
+
+    // Verify builder mode is currently active before the ability change.
+    expect(usePanelStore.getState().panelModes['panel-1']).toBe('builder');
+
+    // Switch to viewer-only ability — builder segment disappears.
+    act(() => {
+      rerender(
+        <ModeSwitch panelId="panel-1" ability={viewerAbility} />,
+      );
+    });
+
+    // The stale 'builder' mode should have been reset to 'editor'.
+    expect(usePanelStore.getState().panelModes['panel-1']).toBe('editor');
+  });
+
+  it('resets workflow mode to editor when ephemeralEnabled flips to false', () => {
+    // Simulate a panel that had workflow mode stored while ephemeral was enabled.
+    usePanelStore.setState({ panelModes: { 'panel-1': 'workflow' } });
+
+    // Start with admin + ephemeral enabled so workflow is a valid segment.
+    const { rerender } = render(
+      <ModeSwitch panelId="panel-1" ability={adminAbility} ephemeralEnabled={true} />,
+      { wrapper: TestProviders },
+    );
+
+    expect(usePanelStore.getState().panelModes['panel-1']).toBe('workflow');
+
+    // Disable ephemeral — workflow segment disappears.
+    act(() => {
+      rerender(
+        <ModeSwitch panelId="panel-1" ability={adminAbility} ephemeralEnabled={false} />,
+      );
+    });
+
+    // The stale 'workflow' mode should have been reset to 'editor'.
+    expect(usePanelStore.getState().panelModes['panel-1']).toBe('editor');
   });
 });
 

--- a/packages/workspace/src/components/WorkspaceShell.tsx
+++ b/packages/workspace/src/components/WorkspaceShell.tsx
@@ -19,8 +19,8 @@
 import '../panels/index';
 
 import React from 'react';
-import { defineAbilitiesFor, type AppAbility } from '@vastu/shared/permissions';
-import { AbilityProvider } from '../providers/AbilityContext';
+import type { AppAbility } from '@vastu/shared/permissions';
+import { AbilityProvider, createNoOpAbility } from '../providers/AbilityContext';
 import { useSidebarStore } from '../stores/sidebarStore';
 import { DockviewHost } from './DockviewHost/DockviewHost';
 import { SidebarNav } from './SidebarNav';
@@ -58,11 +58,6 @@ export interface WorkspaceShellProps {
    * splitting MY VIEWS vs SHARED WITH ME.
    */
   currentUserId?: string;
-}
-
-/** Fallback no-permissions ability when none is provided. */
-function createNoOpAbility(): AppAbility {
-  return defineAbilitiesFor({ roles: [] });
 }
 
 /** Default translations for the sidebar nav. */

--- a/packages/workspace/src/providers/AbilityContext.tsx
+++ b/packages/workspace/src/providers/AbilityContext.tsx
@@ -19,8 +19,13 @@
 import React, { createContext, useContext } from 'react';
 import { defineAbilitiesFor, type AppAbility } from '@vastu/shared/permissions';
 
-/** No-permissions ability used as the default when no provider is present. */
-function createNoOpAbility(): AppAbility {
+/**
+ * No-permissions ability used as the context default when no AbilityProvider
+ * is present, and as a fallback in WorkspaceShell when no ability prop is passed.
+ * Exported so that WorkspaceShell (and any other consumer) can import the single
+ * canonical version rather than defining their own duplicate.
+ */
+export function createNoOpAbility(): AppAbility {
   return defineAbilitiesFor({ roles: [] });
 }
 


### PR DESCRIPTION
Part of feature VASTU-1B-120.\n\nAddresses all four code review findings on PR #261.\n\n- Stale mode reset useEffect in ModeSwitch\n- Deduplicate createNoOpAbility (export from AbilityContext, remove from WorkspaceShell)\n- Two new stale mode test cases\n- TODO comment for ephemeralEnabled in PanelTab\n\nGenerated with Claude Code