### PR TITLE
fix(workspace): address review findings for data explorer [VASTU-1B-132]

### DIFF
--- a/packages/workspace/src/templates/DataExplorer/DataExplorerTemplate.tsx
+++ b/packages/workspace/src/templates/DataExplorer/DataExplorerTemplate.tsx
@@ -38,6 +38,8 @@ import type {
   ExplorerDataRow,
 } from './types';
 
+import { downloadCsv } from './csvUtils';
+
 import classes from './DataExplorerTemplate.module.css';
 
 // ─── Stub data for development ────────────────────────────────────────────────
@@ -133,36 +135,6 @@ function filterDataForSelection(
   });
 }
 
-/** Download the visible table data as a CSV file. */
-function downloadCsv(data: ExplorerDataRow[], columns: VastuColumn<ExplorerDataRow>[]): void {
-  if (columns.length === 0 || data.length === 0) return;
-
-  const header = columns.map((c) => c.label).join(',');
-  const rows = data.map((row) =>
-    columns
-      .map((c) => {
-        const val = row[c.id];
-        if (val === null || val === undefined) return '';
-        const str = String(val);
-        // Escape double quotes and wrap in quotes if needed
-        if (str.includes(',') || str.includes('"') || str.includes('\n')) {
-          return `"${str.replace(/"/g, '""')}"`;
-        }
-        return str;
-      })
-      .join(','),
-  );
-
-  const csv = [header, ...rows].join('\n');
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = 'data-export.csv';
-  link.click();
-  URL.revokeObjectURL(url);
-}
-
 // ─── Inner component (receives resolved config) ───────────────────────────────
 
 interface DataExplorerInnerProps {
@@ -223,6 +195,8 @@ function DataExplorerInner({ pageId: _pageId, metadata, onMetadataChange }: Data
     (key: string | null) => {
       setGroupByKey(key);
       persistMetadata({ groupByKey: key ?? undefined });
+      // TODO: groupByKey filtering is not yet implemented — it persists the selection
+      // but filterDataForSelection does not group rows. Implement in a follow-up task.
     },
     [persistMetadata],
   );
@@ -239,7 +213,8 @@ function DataExplorerInner({ pageId: _pageId, metadata, onMetadataChange }: Data
 
   const xAxisKey = dimensionKey ?? (dimensions[0]?.key ?? 'x');
 
-  const chartData: ChartDataPoint[] = useMemo(
+  // Single memo for the filtered data — shared by both chart and companion table.
+  const filteredData: ChartDataPoint[] = useMemo(
     () => filterDataForSelection(rawData, dimensionKey, measureKeys),
     [rawData, dimensionKey, measureKeys],
   );
@@ -254,11 +229,6 @@ function DataExplorerInner({ pageId: _pageId, metadata, onMetadataChange }: Data
     [dimensionKey, measureKeys, dimensions, measures],
   );
 
-  const tableData: ExplorerDataRow[] = useMemo(
-    () => filterDataForSelection(rawData, dimensionKey, measureKeys),
-    [rawData, dimensionKey, measureKeys],
-  );
-
   // ─── Derived state ────────────────────────────────────────────────────────
 
   const showChart = chartMode !== 'table';
@@ -268,8 +238,8 @@ function DataExplorerInner({ pageId: _pageId, metadata, onMetadataChange }: Data
   // ─── Export handler ───────────────────────────────────────────────────────
 
   const handleExportCsv = useCallback(() => {
-    downloadCsv(tableData, tableColumns);
-  }, [tableData, tableColumns]);
+    downloadCsv(filteredData, tableColumns);
+  }, [filteredData, tableColumns]);
 
   // ─── Render ───────────────────────────────────────────────────────────────
 
@@ -307,9 +277,10 @@ function DataExplorerInner({ pageId: _pageId, metadata, onMetadataChange }: Data
           {/* ── Chart ─────────────────────────────────────────────────── */}
           {showChart && (
             <div className={classes.chartArea}>
+              {/* TODO (stretch): add brush/zoom controls and PNG export (US-132 non-core ACs) */}
               <VastuChart
                 type={chartType}
-                data={chartData}
+                data={filteredData}
                 series={series}
                 config={{ xAxisKey, height: 280, showLegend: series.length > 1 }}
                 ariaLabel={t('explorer.chart.ariaLabel')}
@@ -329,14 +300,14 @@ function DataExplorerInner({ pageId: _pageId, metadata, onMetadataChange }: Data
                 leftSection={<IconDownload size={12} aria-hidden="true" />}
                 onClick={handleExportCsv}
                 aria-label={t('explorer.export.csv.ariaLabel')}
-                disabled={tableData.length === 0}
+                disabled={filteredData.length === 0}
               >
                 {t('explorer.export.csv.label')}
               </Button>
             </div>
             <div className={classes.tableContainer}>
               <VastuTable
-                data={tableData}
+                data={filteredData}
                 columns={tableColumns}
                 ariaLabel={t('explorer.table.ariaLabel')}
                 height="100%"

--- a/packages/workspace/src/templates/DataExplorer/__tests__/DataExplorerTemplate.test.tsx
+++ b/packages/workspace/src/templates/DataExplorer/__tests__/DataExplorerTemplate.test.tsx
@@ -23,6 +23,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { DataExplorerTemplate } from '../DataExplorerTemplate';
 import { ChartTypeToggle } from '../ChartTypeToggle';
 import { ExplorerControls } from '../ExplorerControls';
+import {
+  sanitizeCsvCell,
+  escapeCsvCell,
+  escapeCsvHeader,
+  buildCsvString,
+} from '../csvUtils';
 import type { TemplateConfig } from '../../types';
 import type { ExplorerChartMode } from '../types';
 
@@ -239,5 +245,107 @@ describe('ExplorerControls', () => {
     expect(screen.getByText('Dimension')).toBeInTheDocument();
     expect(screen.getByText('Measures')).toBeInTheDocument();
     expect(screen.getByText('Group by')).toBeInTheDocument();
+  });
+});
+
+// ─── CSV utility unit tests ────────────────────────────────────────────────────
+
+describe('sanitizeCsvCell', () => {
+  it('prefixes values starting with = to prevent formula injection', () => {
+    expect(sanitizeCsvCell('=SUM(A1:A10)')).toBe("'=SUM(A1:A10)");
+  });
+
+  it('prefixes values starting with + to prevent injection', () => {
+    expect(sanitizeCsvCell('+cmd|\'dir\'')).toBe("'+cmd|'dir'");
+  });
+
+  it('prefixes values starting with - to prevent injection', () => {
+    expect(sanitizeCsvCell('-2+3')).toBe("'-2+3");
+  });
+
+  it('prefixes values starting with @ to prevent injection', () => {
+    expect(sanitizeCsvCell('@SUM(1)')).toBe("'@SUM(1)");
+  });
+
+  it('does not modify safe values', () => {
+    expect(sanitizeCsvCell('hello world')).toBe('hello world');
+    expect(sanitizeCsvCell('100')).toBe('100');
+    expect(sanitizeCsvCell('')).toBe('');
+  });
+});
+
+describe('escapeCsvCell', () => {
+  it('returns empty quoted string for null', () => {
+    expect(escapeCsvCell(null)).toBe('""');
+  });
+
+  it('returns empty quoted string for undefined', () => {
+    expect(escapeCsvCell(undefined)).toBe('""');
+  });
+
+  it('wraps numeric values in quotes', () => {
+    expect(escapeCsvCell(42000)).toBe('"42000"');
+  });
+
+  it('wraps string values in quotes', () => {
+    expect(escapeCsvCell('hello')).toBe('"hello"');
+  });
+
+  it('escapes internal double-quotes by doubling', () => {
+    expect(escapeCsvCell('say "hello"')).toBe('"say ""hello"""');
+  });
+
+  it('sanitizes injection characters before quoting', () => {
+    expect(escapeCsvCell('=HYPERLINK("evil.com")')).toBe(`"'=HYPERLINK(""evil.com"")"`);
+  });
+});
+
+describe('escapeCsvHeader', () => {
+  it('wraps header labels in double-quotes', () => {
+    expect(escapeCsvHeader('Revenue')).toBe('"Revenue"');
+  });
+
+  it('escapes internal double-quotes in headers', () => {
+    expect(escapeCsvHeader('Say "Hi"')).toBe('"Say ""Hi"""');
+  });
+});
+
+describe('buildCsvString', () => {
+  it('returns empty string when data is empty', () => {
+    const cols = [{ id: 'name', label: 'Name', accessorKey: 'name', dataType: 'text' as const, sortable: true }];
+    expect(buildCsvString([], cols)).toBe('');
+  });
+
+  it('returns empty string when columns are empty', () => {
+    expect(buildCsvString([{ name: 'Alice' }], [])).toBe('');
+  });
+
+  it('generates quoted headers and data rows', () => {
+    const cols = [
+      { id: 'month', label: 'Month', accessorKey: 'month', dataType: 'text' as const, sortable: true },
+      { id: 'revenue', label: 'Revenue', accessorKey: 'revenue', dataType: 'number' as const, sortable: true },
+    ];
+    const data = [{ month: 'Jan', revenue: 42000 }];
+    const result = buildCsvString(data, cols);
+    expect(result).toBe('"Month","Revenue"\n"Jan","42000"');
+  });
+
+  it('sanitizes injection characters in cell values', () => {
+    const cols = [
+      { id: 'formula', label: 'Formula', accessorKey: 'formula', dataType: 'text' as const, sortable: true },
+    ];
+    const data = [{ formula: '=SUM(A1)' }];
+    const result = buildCsvString(data, cols);
+    // Cell should be prefixed with single-quote then wrapped in double-quotes
+    expect(result).toContain("\"'=SUM(A1)\"");
+  });
+
+  it('handles null/undefined cell values as empty quoted strings', () => {
+    const cols = [
+      { id: 'val', label: 'Value', accessorKey: 'val', dataType: 'text' as const, sortable: true },
+    ];
+    const data = [{ val: null }, { val: undefined }];
+    const result = buildCsvString(data, cols);
+    expect(result).toBe('"Value"\n""\n""');
   });
 });

--- a/packages/workspace/src/templates/DataExplorer/csvUtils.ts
+++ b/packages/workspace/src/templates/DataExplorer/csvUtils.ts
@@ -1,0 +1,68 @@
+/**
+ * CSV generation utilities for DataExplorerTemplate.
+ *
+ * Implements RFC 4180 escaping and OWASP CSV injection prevention.
+ * See: https://owasp.org/www-community/attacks/CSV_Injection
+ */
+
+import type { VastuColumn } from '../../components/VastuTable/types';
+import type { ExplorerDataRow } from './types';
+
+/**
+ * Characters that spreadsheet applications interpret as formula prefixes.
+ * Prefix them with a single-quote to neutralise the formula.
+ */
+const CSV_INJECTION_CHARS = /^[=+\-@\t\r]/;
+
+/** Sanitize a CSV cell value to prevent CSV injection. */
+export function sanitizeCsvCell(value: string): string {
+  if (CSV_INJECTION_CHARS.test(value)) {
+    return `'${value}`;
+  }
+  return value;
+}
+
+/** Escape and quote a CSV cell value per RFC 4180. */
+export function escapeCsvCell(raw: string | number | null | undefined): string {
+  if (raw === null || raw === undefined) return '""';
+  const str = sanitizeCsvCell(String(raw));
+  // Always quote: escape internal double-quotes by doubling them
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+/** Escape and quote a CSV header value per RFC 4180. */
+export function escapeCsvHeader(label: string): string {
+  // Always quote headers and escape internal double-quotes
+  return `"${label.replace(/"/g, '""')}"`;
+}
+
+/** Build the CSV string from data rows and column definitions. Returns empty string when inputs are empty. */
+export function buildCsvString(
+  data: ExplorerDataRow[],
+  columns: VastuColumn<ExplorerDataRow>[],
+): string {
+  if (columns.length === 0 || data.length === 0) return '';
+
+  const header = columns.map((c) => escapeCsvHeader(c.label)).join(',');
+  const rows = data.map((row) => columns.map((c) => escapeCsvCell(row[c.id])).join(','));
+
+  return [header, ...rows].join('\n');
+}
+
+/** Download the visible table data as a CSV file. */
+export function downloadCsv(
+  data: ExplorerDataRow[],
+  columns: VastuColumn<ExplorerDataRow>[],
+): void {
+  const csv = buildCsvString(data, columns);
+  if (!csv) return;
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'data-export.csv';
+  link.click();
+  // Delay revocation to allow the browser to start the download
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}


### PR DESCRIPTION
Part of feature VASTU-1B-132.

## Summary
- Fix all must-fix and should-fix findings from PR #287 code review and QA

## Must-fix items addressed
- **CSV injection (finding 1):** Extracted `sanitizeCsvCell` in `csvUtils.ts` that prefixes cells starting with `=`, `+`, `-`, `@`, `\t`, `\r` with a single-quote per OWASP CSV injection guidance
- **Unescaped CSV headers (finding 2):** `escapeCsvHeader` now always wraps header labels in double-quotes and doubles internal double-quotes (RFC 4180)
- **Premature revokeObjectURL (finding 3):** Changed to `setTimeout(() => URL.revokeObjectURL(url), 1000)` to allow download to start
- **Missing brush/zoom (finding 4):** Added `// TODO (stretch): add brush/zoom controls and PNG export (US-132 non-core ACs)` comment in chart area

## Should-fix items addressed
- **Duplicate memoization (finding 5):** Consolidated `chartData` and `tableData` (both computed identically) into a single `filteredData` memo used by both chart and companion table
- **No tests for downloadCsv (finding 6):** Added 15 unit tests in the test file covering `sanitizeCsvCell`, `escapeCsvCell`, `escapeCsvHeader`, and `buildCsvString` (injection, escaping, empty data, null/undefined cells)
- **groupByKey not implemented (finding 7):** Added TODO comment in `handleGroupByChange` explaining the limitation and that it should be implemented in a follow-up task

## Files changed
- `packages/workspace/src/templates/DataExplorer/DataExplorerTemplate.tsx` — consolidate memos, import from csvUtils, add TODO comments
- `packages/workspace/src/templates/DataExplorer/csvUtils.ts` — new file with exported CSV utilities
- `packages/workspace/src/templates/DataExplorer/__tests__/DataExplorerTemplate.test.tsx` — 15 new unit tests for CSV utilities

## Test plan
- [x] `pnpm --filter workspace test -- --run` passes (646 passed, 1 skipped)
- [x] `pnpm --filter workspace typecheck` passes (clean)
- [x] Injection cells verified by unit test (e.g. `=SUM(A1)` → `"'=SUM(A1)"`)
- [x] Headers verified by unit test (`Revenue` → `"Revenue"`)
- [x] Empty data returns empty string, not a crash