### PR TITLE
test(workspace): add workspace E2E tests [VASTU-1B-127]

### DIFF
--- a/packages/shell/e2e/workspace/builder-mode.spec.ts
+++ b/packages/shell/e2e/workspace/builder-mode.spec.ts
@@ -2,18 +2,10 @@
  * E2E tests - Builder mode config panel (US-136)
  * PR: https://github.com/vichitra-paheli/Vastu/pull/304
  */
+// Auth protection for /workspace is covered by workspace.spec.ts — not duplicated here.
+
 import { test, expect } from "@playwright/test";
 import { loginAs, TEST_USERS } from "../fixtures";
-
-// Auth protection (no Docker required)
-
-test.describe("Builder mode - auth protection", () => {
-  test("redirects unauthenticated users to /login", async ({ page }) => {
-    await page.context().clearCookies();
-    await page.goto("/workspace");
-    await expect(page).toHaveURL(/\/login/);
-  });
-});
 
 // AC-1: Builder mode replaces panel content
 

--- a/packages/shell/e2e/workspace/command-palette.spec.ts
+++ b/packages/shell/e2e/workspace/command-palette.spec.ts
@@ -22,18 +22,6 @@ import { WorkspacePage, WS } from './fixtures/workspace-page';
 import { BUILT_IN_COMMANDS } from './fixtures/seed-data';
 
 // ---------------------------------------------------------------------------
-// Auth protection (no Docker required)
-// ---------------------------------------------------------------------------
-
-test.describe('Command palette — auth protection', () => {
-  test('unauthenticated access to /workspace redirects to /login', async ({ page }) => {
-    await page.context().clearCookies();
-    await page.goto('/workspace');
-    await expect(page).toHaveURL(/\/login/);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // AC-6: Open via keyboard shortcut
 // ---------------------------------------------------------------------------
 
@@ -113,9 +101,7 @@ test.describe('Command palette — AC-6: search and result groups', () => {
     await ws.commandPalette.openViaKeyboard();
     await ws.commandPalette.type('Dashboard');
 
-    // Wait for results to appear after the 150ms debounce.
-    await page.waitForTimeout(300);
-
+    // Wait for results to appear (auto-retrying assertion handles the debounce).
     await expect(ws.commandPalette.results.filter({ hasText: 'Dashboard' }).first()).toBeVisible({
       timeout: 5_000,
     });
@@ -130,9 +116,8 @@ test.describe('Command palette — AC-6: search and result groups', () => {
     // Typing ">" activates commands-only mode.
     await ws.commandPalette.openViaKeyboard();
     await ws.commandPalette.type('>');
-    await page.waitForTimeout(300);
 
-    // All built-in command labels should appear.
+    // All built-in command labels should appear (auto-retrying assertion).
     for (const command of BUILT_IN_COMMANDS) {
       await expect(
         ws.commandPalette.results.filter({ hasText: command }).first(),
@@ -148,9 +133,8 @@ test.describe('Command palette — AC-6: search and result groups', () => {
 
     await ws.commandPalette.openViaKeyboard();
     await ws.commandPalette.type('zzz-no-match-zzz');
-    await page.waitForTimeout(300);
 
-    // Mantine Spotlight.Empty renders the no-results message.
+    // Mantine Spotlight.Empty renders the no-results message (auto-retrying assertion).
     await expect(page.locator(WS.commandPaletteEmpty)).toBeVisible({ timeout: 5_000 });
     await expect(page.locator(WS.commandPaletteEmpty)).toContainText('zzz-no-match-zzz');
   });
@@ -174,9 +158,8 @@ test.describe('Command palette — AC-6: search and result groups', () => {
 
     await ws.commandPalette.openViaKeyboard();
     await ws.commandPalette.type('>');
-    await page.waitForTimeout(300);
 
-    // The commands-mode hint banner should appear.
+    // The commands-mode hint banner should appear (auto-retrying assertion).
     const hint = page.locator('[aria-live="polite"]').filter({ hasText: /command/i });
     await expect(hint).toBeVisible({ timeout: 3_000 });
   });
@@ -198,7 +181,11 @@ test.describe('Command palette — AC-6: select result opens panel', () => {
     // Open palette and search for "Contacts".
     await ws.commandPalette.openViaKeyboard();
     await ws.commandPalette.type('Contacts');
-    await page.waitForTimeout(300);
+
+    // Wait for the Contacts result to appear before clicking (auto-retrying).
+    await expect(ws.commandPalette.results.filter({ hasText: 'Contacts' }).first()).toBeVisible({
+      timeout: 5_000,
+    });
 
     // Click the Contacts result.
     await ws.commandPalette.selectResult('Contacts');
@@ -223,7 +210,11 @@ test.describe('Command palette — AC-6: select result opens panel', () => {
 
     await ws.commandPalette.openViaKeyboard();
     await ws.commandPalette.type('>toggle');
-    await page.waitForTimeout(300);
+
+    // Wait for the Toggle sidebar result to appear (auto-retrying assertion).
+    await expect(
+      ws.commandPalette.results.filter({ hasText: 'Toggle sidebar' }).first(),
+    ).toBeVisible({ timeout: 5_000 });
 
     await ws.commandPalette.selectResult('Toggle sidebar');
 
@@ -243,7 +234,9 @@ test.describe('Command palette — AC-6: select result opens panel', () => {
 
     await ws.commandPalette.openViaKeyboard();
     await ws.commandPalette.type('a');
-    await page.waitForTimeout(300);
+
+    // Wait for at least one result to appear before pressing ArrowDown (auto-retrying).
+    await expect(ws.commandPalette.results.first()).toBeVisible({ timeout: 5_000 });
 
     // Press ArrowDown to move focus to the first result.
     await page.keyboard.press('ArrowDown');
@@ -261,7 +254,11 @@ test.describe('Command palette — AC-6: select result opens panel', () => {
 
     await ws.commandPalette.openViaKeyboard();
     await ws.commandPalette.type('Dashboard');
-    await page.waitForTimeout(300);
+
+    // Wait for the Dashboard result to appear before navigating (auto-retrying).
+    await expect(ws.commandPalette.results.filter({ hasText: 'Dashboard' }).first()).toBeVisible({
+      timeout: 5_000,
+    });
 
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');

--- a/packages/shell/e2e/workspace/dashboard-view.spec.ts
+++ b/packages/shell/e2e/workspace/dashboard-view.spec.ts
@@ -1,10 +1,26 @@
+/**
+ * E2E tests — Dashboard view (US-127)
+ *
+ * Auth protection for /workspace is covered by workspace.spec.ts
+ * (canonical auth-protection tests live there, not duplicated here).
+ *
+ * Dashboard-specific tests will be added here when dashboard view
+ * functionality is implemented.
+ */
+
 import { test, expect } from '@playwright/test';
 import { loginAs, TEST_USERS } from '../fixtures';
+import { WorkspacePage } from './fixtures/workspace-page';
 
-test.describe('Dashboard view - auth protection', () => {
-  test('redirects unauthenticated users to /login', async ({ page }) => {
-    await page.context().clearCookies();
-    await page.goto('/workspace');
-    await expect(page).toHaveURL(/\/login/);
+test.describe('Dashboard view', () => {
+  test.skip('dashboard panel renders after login', async ({ page }) => {
+    // Requires: docker compose up -d
+    await loginAs(page, TEST_USERS.admin.email, TEST_USERS.admin.password);
+    const ws = new WorkspacePage(page);
+    await ws.waitForShell();
+
+    await ws.sidebar.clickItem('Dashboard');
+
+    await expect(page.getByTestId('dashboard-panel')).toBeVisible({ timeout: 8_000 });
   });
 });

--- a/packages/shell/e2e/workspace/fixtures/seed-data.ts
+++ b/packages/shell/e2e/workspace/fixtures/seed-data.ts
@@ -12,31 +12,40 @@
  * Seed user IDs and credentials match auth-setup.ts and fixtures.ts.
  */
 
+import { TEST_USERS } from '../../fixtures';
+
 // ---------------------------------------------------------------------------
 // Seed users
 // ---------------------------------------------------------------------------
 
+/**
+ * Workspace seed users — extends TEST_USERS from shell fixtures with
+ * workspace-specific fields (id, role) that are not needed in shell auth tests.
+ *
+ * Credentials (email/password) are sourced from the canonical TEST_USERS so
+ * that there is a single source of truth and no duplication.
+ */
 export const SEED_USERS = {
   admin: {
     id: 'cccccccc-0000-4000-a000-000000000001',
-    email: 'admin@vastu.dev',
-    password: 'Admin1234!',
-    name: 'Admin User',
-    role: 'Admin',
+    email: TEST_USERS.admin.email,
+    password: TEST_USERS.admin.password,
+    name: TEST_USERS.admin.name,
+    role: TEST_USERS.admin.role,
   },
   editor: {
     id: 'cccccccc-0000-4000-a000-000000000002',
-    email: 'editor@vastu.dev',
-    password: 'Editor1234!',
-    name: 'Editor User',
-    role: 'Editor',
+    email: TEST_USERS.editor.email,
+    password: TEST_USERS.editor.password,
+    name: TEST_USERS.editor.name,
+    role: TEST_USERS.editor.role,
   },
   viewer: {
     id: 'cccccccc-0000-4000-a000-000000000003',
-    email: 'viewer@vastu.dev',
-    password: 'Viewer1234!',
-    name: 'Viewer User',
-    role: 'Viewer',
+    email: TEST_USERS.viewer.email,
+    password: TEST_USERS.viewer.password,
+    name: TEST_USERS.viewer.name,
+    role: TEST_USERS.viewer.role,
   },
 } as const;
 
@@ -70,11 +79,16 @@ export const FIRST_SIDEBAR_PAGE = MOCK_SIDEBAR_PAGES[0];
 
 /**
  * Commands available in the command palette COMMANDS group.
- * These match the built-in commands registered via useCommandPaletteActions.
+ * These match the built-in commands registered via useCommandPaletteActions
+ * (packages/workspace/src/hooks/useCommandPaletteActions.ts).
+ * Update this list whenever buildStaticCommands changes.
  */
 export const BUILT_IN_COMMANDS = [
   'Toggle sidebar',
-  'Show keyboard shortcuts',
+  'New panel',
+  'Close all panels',
+  'Open settings',
+  'Keyboard shortcuts',
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -131,6 +145,12 @@ export interface SampleView {
   pageId: string;
   createdBy: string;
   isShared: boolean;
+  /**
+   * Hex color string stored in the database as serialized view state.
+   * These are raw persisted values, NOT UI-rendered colors — CSS custom
+   * properties (--v-*) do not apply here. The hex value is stored as-is
+   * and rendered into a small color dot indicator in the ViewSelector.
+   */
   colorDot: string;
 }
 

--- a/packages/shell/e2e/workspace/fixtures/workspace-page.ts
+++ b/packages/shell/e2e/workspace/fixtures/workspace-page.ts
@@ -36,12 +36,21 @@ export const WS = {
   sidebarToggleCollapse: '[aria-label="Collapse sidebar"]',
   sidebarToggleExpand: '[aria-label="Expand sidebar"]',
   sidebarSearch: '[placeholder="Search pages..."]',
-  sidebarNavItem: '[data-testid^="sidebar-item-"]',
+  // SidebarItem renders data-item-id={id} on the <button> element (not data-testid).
+  // See packages/workspace/src/components/SidebarNav/SidebarItem.tsx.
+  sidebarNavItem: '[data-item-id]',
 
-  // Dockview
+  // Dockview — internal CSS selectors from Dockview v4.x.
+  // These classes are part of Dockview's internal DOM structure and may change
+  // if the Dockview version is upgraded. Update these selectors when bumping
+  // the dockview package version.
+  // Dockview v4.x internal selector — update if Dockview version changes.
   dockviewContainer: '.dv-react-dockview',
+  // Dockview v4.x internal selector — update if Dockview version changes.
   dockviewTab: '.dv-tab',
+  // Dockview v4.x internal selector — update if Dockview version changes.
   dockviewActiveTab: '.dv-tab.dv-active-tab',
+  // Dockview v4.x internal selector — update if Dockview version changes.
   dockviewPanelContent: '.dv-panel-content',
 
   // TrayBar
@@ -52,8 +61,9 @@ export const WS = {
   trayItemChip: '[data-testid^="tray-item-"]',
 
   // CommandPalette (Mantine Spotlight)
+  // The aria-label value matches commandPalette.searchAriaLabel in en.json.
   commandPaletteRoot: '[data-testid="command-palette"]',
-  commandPaletteSearch: '[aria-label="Search pages, records and commands"]',
+  commandPaletteSearch: '[aria-label="Search command palette"]',
   commandPaletteResult: '[data-testid^="cp-result-"]',
   commandPaletteEmpty: '[class*="emptyState"]',
   commandPaletteFooter: '[class*="footer"]',
@@ -70,11 +80,17 @@ export const WS = {
   tableFooter: '[role="status"][aria-live="polite"]',
   tableSortIcon: '[data-testid^="sort-icon-"]',
 
-  // ViewToolbar
-  viewToolbar: '[data-testid="view-toolbar"]',
-  viewName: '[data-testid="view-name"]',
-  viewSaveButton: '[data-testid="view-save-button"]',
-  viewResetButton: '[data-testid="view-reset-button"]',
+  // ViewToolbar — selectors match ViewToolbar.tsx actual data-testid values.
+  // The toolbar root uses role="toolbar" with an aria-label; individual
+  // controls use the data-testid values rendered in the component.
+  // See packages/workspace/src/components/ViewToolbar/ViewToolbar.tsx.
+  viewToolbar: '[role="toolbar"]',
+  // The view name is an <input> with aria-label matching view.toolbar.viewNameAriaLabel.
+  viewName: '[aria-label][class*="viewNameInput"]',
+  // Save button uses data-testid="save-button" (not "view-save-button").
+  viewSaveButton: '[data-testid="save-button"]',
+  // Reset button uses data-testid="reset-button" (not "view-reset-button").
+  viewResetButton: '[data-testid="reset-button"]',
   viewSelector: '[aria-label*="view selector"], [aria-label*="View selector"]',
 } as const;
 
@@ -159,9 +175,12 @@ export class TrayPOM {
 export class CommandPalettePOM {
   constructor(private readonly page: Page) {}
 
-  /** Open via keyboard shortcut (Cmd/Ctrl+K). */
+  /** Open via keyboard shortcut (Cmd+K on macOS, Ctrl+K on Windows/Linux). */
   async openViaKeyboard(): Promise<void> {
-    await this.page.keyboard.press('Meta+k');
+    // Meta+k works on macOS; Control+k is the cross-platform fallback.
+    // Playwright's page.keyboard.press supports both modifier names.
+    const isMac = process.platform === 'darwin';
+    await this.page.keyboard.press(isMac ? 'Meta+k' : 'Control+k');
   }
 
   /** Open via the tray search button. */

--- a/packages/shell/e2e/workspace/mode-switch.spec.ts
+++ b/packages/shell/e2e/workspace/mode-switch.spec.ts
@@ -23,18 +23,6 @@ import { loginAs, TEST_USERS } from '../fixtures';
 import { WorkspacePage, WS } from './fixtures/workspace-page';
 
 // ---------------------------------------------------------------------------
-// Auth protection (no Docker required)
-// ---------------------------------------------------------------------------
-
-test.describe('Mode switch — auth protection', () => {
-  test('unauthenticated access to /workspace redirects to /login', async ({ page }) => {
-    await page.context().clearCookies();
-    await page.goto('/workspace');
-    await expect(page).toHaveURL(/\/login/);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // AC-10: Mode switch visible state
 // ---------------------------------------------------------------------------
 
@@ -75,7 +63,10 @@ test.describe('Mode switch — AC-10: visibility by role', () => {
     await ws.waitForShell();
 
     await ws.sidebar.clickItem('Dashboard');
-    await page.waitForTimeout(2_000); // wait for panel to settle
+
+    // Wait for the Dockview panel content to appear before asserting the
+    // ModeSwitch is absent (auto-retrying with generous timeout).
+    await expect(page.locator(WS.dockviewPanelContent).first()).toBeVisible({ timeout: 8_000 });
 
     // ModeSwitch should not be visible for editors.
     await expect(page.locator(WS.modeSwitchGroup)).not.toBeVisible();
@@ -88,7 +79,10 @@ test.describe('Mode switch — AC-10: visibility by role', () => {
     await ws.waitForShell();
 
     await ws.sidebar.clickItem('Dashboard');
-    await page.waitForTimeout(2_000);
+
+    // Wait for the Dockview panel content to appear before asserting the
+    // ModeSwitch is absent (auto-retrying with generous timeout).
+    await expect(page.locator(WS.dockviewPanelContent).first()).toBeVisible({ timeout: 8_000 });
 
     await expect(page.locator(WS.modeSwitchGroup)).not.toBeVisible();
   });

--- a/packages/shell/e2e/workspace/table-interactions.spec.ts
+++ b/packages/shell/e2e/workspace/table-interactions.spec.ts
@@ -28,18 +28,6 @@ import { loginAs, TEST_USERS } from '../fixtures';
 import { WorkspacePage, WS } from './fixtures/workspace-page';
 
 // ---------------------------------------------------------------------------
-// Auth protection (no Docker required)
-// ---------------------------------------------------------------------------
-
-test.describe('Table interactions — auth protection', () => {
-  test('unauthenticated access to /workspace redirects to /login', async ({ page }) => {
-    await page.context().clearCookies();
-    await page.goto('/workspace');
-    await expect(page).toHaveURL(/\/login/);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Shared helper: navigate to a page that renders a VastuTable
 // ---------------------------------------------------------------------------
 
@@ -66,82 +54,65 @@ test.describe('Table interactions — AC-7: column sort', () => {
     // Requires: docker compose up -d + seeded Contacts data
     const ws = await openTablePage(page);
 
-    // Get the first cell value in the Name column before sorting.
-    const firstRowBefore = await page.locator(WS.tableRow).first().textContent();
-
     // Click the "Name" column header to sort ascending.
     await ws.table.clickHeader('Name');
 
-    // Wait briefly for the sort to apply.
-    await page.waitForTimeout(500);
+    // Wait for the sort indicator to appear on the Name header (auto-retrying).
+    const nameHeader = page.locator(WS.tableHeaderRow).filter({ hasText: /^name$/i });
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending', { timeout: 5_000 });
 
-    const firstRowAfter = await page.locator(WS.tableRow).first().textContent();
-
-    // After sorting the first row may differ (if data wasn't already sorted).
-    // We can't know the exact expected value without the database, so we assert
-    // the table still renders rows.
-    const rowCount = await page.locator(WS.tableRow).count();
-    expect(rowCount).toBeGreaterThan(0);
-    // The sort interaction completed without error (row content may or may not change).
-    expect(typeof firstRowAfter).toBe('string');
-    // Suppress unused variable warning.
-    void firstRowBefore;
+    // Table must still render rows after sorting.
+    await expect(page.locator(WS.tableRow).first()).toBeVisible({ timeout: 5_000 });
   });
 
   test.skip('clicking a sorted column header again reverses the sort order', async ({ page }) => {
     // Requires: docker compose up -d + seeded Contacts data
     const ws = await openTablePage(page);
 
-    // Click once → ascending, click again → descending.
-    await ws.table.clickHeader('Name');
-    await page.waitForTimeout(300);
-    await ws.table.clickHeader('Name');
-    await page.waitForTimeout(300);
+    const nameHeader = page.locator(WS.tableHeaderRow).filter({ hasText: /^name$/i });
 
-    // Table should still render rows (no crash on sort toggle).
-    const rowCount = await page.locator(WS.tableRow).count();
-    expect(rowCount).toBeGreaterThan(0);
+    // Click once → ascending.
+    await ws.table.clickHeader('Name');
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending', { timeout: 5_000 });
+
+    // Click again → descending.
+    await ws.table.clickHeader('Name');
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'descending', { timeout: 5_000 });
   });
 
   test.skip('sort indicator icon appears after clicking a column header', async ({ page }) => {
     // Requires: docker compose up -d + seeded Contacts data
     const ws = await openTablePage(page);
 
-    // Before clicking there should be no active sort indicator.
-    const sortedHeader = page
-      .locator(WS.tableHeaderRow)
-      .filter({ has: page.locator('[aria-sort]') });
-    const beforeCount = await sortedHeader.count();
+    // Before clicking, the Name header should have no sort direction.
+    const nameHeader = page.locator(WS.tableHeaderRow).filter({ hasText: /^name$/i });
 
     await ws.table.clickHeader('Name');
-    await page.waitForTimeout(300);
 
-    // After clicking, at least one header should carry an aria-sort attribute.
-    const afterCount = await sortedHeader.count();
-    expect(afterCount).toBeGreaterThanOrEqual(beforeCount);
+    // After clicking, the Name header should carry an aria-sort attribute.
+    await expect(nameHeader).toHaveAttribute('aria-sort', /(ascending|descending)/, {
+      timeout: 5_000,
+    });
   });
 
   test.skip('row order changes after sorting by a numeric column', async ({ page }) => {
     // Requires: docker compose up -d + seeded Contacts data with a numeric column
     await openTablePage(page);
 
-    // Capture text of first row before sort.
-    const before = await page.locator(WS.tableRow).first().textContent();
-
-    // Sort by "Amount" column (if present — gracefully skip if not).
+    // Sort by "Amount" column (if present — skip if not in the seed data).
     const amountHeader = page.locator(WS.tableHeaderRow).filter({ hasText: /amount/i });
     if ((await amountHeader.count()) === 0) {
       test.info().annotations.push({ type: 'note', description: 'Amount column not found' });
       return;
     }
     await amountHeader.first().click();
-    await page.waitForTimeout(500);
 
-    const after = await page.locator(WS.tableRow).first().textContent();
-    // The first row may differ after sorting by amount.
-    // We can't know the exact value without DB data, so just check rows exist.
-    expect(after).toBeTruthy();
-    void before;
+    // Wait for the sort indicator to confirm the sort applied (auto-retrying).
+    await expect(amountHeader.first()).toHaveAttribute('aria-sort', /(ascending|descending)/, {
+      timeout: 5_000,
+    });
+    // Table must remain visible after sort.
+    await expect(page.locator(WS.tableRow).first()).toBeVisible({ timeout: 5_000 });
   });
 
   test.skip('sorting does not affect row count', async ({ page }) => {
@@ -150,11 +121,9 @@ test.describe('Table interactions — AC-7: column sort', () => {
 
     const countBefore = await page.locator(WS.tableRow).count();
     await ws.table.clickHeader('Name');
-    await page.waitForTimeout(300);
-    const countAfter = await page.locator(WS.tableRow).count();
 
-    // Sorting should not add or remove rows.
-    expect(countAfter).toBe(countBefore);
+    // Wait for sort to settle before counting (auto-retrying via toHaveCount).
+    await expect(page.locator(WS.tableRow)).toHaveCount(countBefore, { timeout: 5_000 });
   });
 });
 
@@ -194,15 +163,15 @@ test.describe('Table interactions — AC-8: filter pills', () => {
       .nth(1);
     await firstDataCell.click({ button: 'right' });
 
-    // The context menu value is shown in the Include filter item.
+    // The "Include" context menu item must be present (fails test if missing).
     const includeItem = page.getByRole('menuitem', { name: /include/i });
-    if (await includeItem.isVisible()) {
-      await includeItem.click();
+    await expect(includeItem).toBeVisible({ timeout: 5_000 });
+    await includeItem.click();
 
-      // A filter pill should appear in the FilterBar above the table.
-      const filterPill = page.locator('[data-testid^="filter-pill-"]').first();
-      await expect(filterPill).toBeVisible({ timeout: 5_000 });
-    }
+    // A filter pill should appear in the FilterBar above the table (auto-retrying).
+    await expect(page.locator('[data-testid^="filter-pill-"]').first()).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   test.skip('applying a filter reduces the visible row count', async ({ page }) => {
@@ -220,14 +189,17 @@ test.describe('Table interactions — AC-8: filter pills', () => {
     await firstDataCell.click({ button: 'right' });
 
     const includeItem = page.getByRole('menuitem', { name: /include/i });
-    if (await includeItem.isVisible()) {
-      await includeItem.click();
-      await page.waitForTimeout(500);
+    await expect(includeItem).toBeVisible({ timeout: 5_000 });
+    await includeItem.click();
 
-      const filteredRows = await page.locator(WS.tableRow).count();
-      // Filtered row count should be <= total rows.
-      expect(filteredRows).toBeLessThanOrEqual(totalRows);
-    }
+    // Wait for the filter pill to appear, confirming the filter was applied.
+    await expect(page.locator('[data-testid^="filter-pill-"]').first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Filtered row count should be <= total rows (auto-retrying assertion).
+    const filteredRows = await page.locator(WS.tableRow).count();
+    expect(filteredRows).toBeLessThanOrEqual(totalRows);
   });
 
   test.skip('filter pill can be removed by clicking its dismiss button', async ({ page }) => {
@@ -245,25 +217,20 @@ test.describe('Table interactions — AC-8: filter pills', () => {
     await firstDataCell.click({ button: 'right' });
 
     const includeItem = page.getByRole('menuitem', { name: /include/i });
-    if (await includeItem.isVisible()) {
-      await includeItem.click();
-      await page.waitForTimeout(300);
+    await expect(includeItem).toBeVisible({ timeout: 5_000 });
+    await includeItem.click();
 
-      // Remove the filter pill.
-      const pillRemoveButton = page
-        .locator('[data-testid^="filter-pill-"]')
-        .first()
-        .getByRole('button', { name: /remove|close|dismiss/i });
+    // Wait for the filter pill to appear before removing it.
+    const filterPill = page.locator('[data-testid^="filter-pill-"]').first();
+    await expect(filterPill).toBeVisible({ timeout: 5_000 });
 
-      if (await pillRemoveButton.isVisible()) {
-        await pillRemoveButton.click();
-        await page.waitForTimeout(300);
+    // Remove the filter pill.
+    const pillRemoveButton = filterPill.getByRole('button', { name: /remove|close|dismiss/i });
+    await expect(pillRemoveButton).toBeVisible({ timeout: 5_000 });
+    await pillRemoveButton.click();
 
-        // Row count should return to original.
-        const restoredRows = await page.locator(WS.tableRow).count();
-        expect(restoredRows).toBe(totalRows);
-      }
-    }
+    // Row count should return to original (auto-retrying assertion).
+    await expect(page.locator(WS.tableRow)).toHaveCount(totalRows, { timeout: 5_000 });
   });
 
   test.skip('applying an Exclude filter removes matching rows', async ({ page }) => {
@@ -271,7 +238,6 @@ test.describe('Table interactions — AC-8: filter pills', () => {
     await openTablePage(page);
 
     const totalRows = await page.locator(WS.tableRow).count();
-    if (totalRows === 0) return;
 
     // Right-click the first data cell.
     const firstDataCell = page
@@ -282,14 +248,17 @@ test.describe('Table interactions — AC-8: filter pills', () => {
     await firstDataCell.click({ button: 'right' });
 
     const excludeItem = page.getByRole('menuitem', { name: /exclude/i });
-    if (await excludeItem.isVisible()) {
-      await excludeItem.click();
-      await page.waitForTimeout(500);
+    await expect(excludeItem).toBeVisible({ timeout: 5_000 });
+    await excludeItem.click();
 
-      // After excluding, matching rows should be hidden.
-      const filteredRows = await page.locator(WS.tableRow).count();
-      expect(filteredRows).toBeLessThanOrEqual(totalRows);
-    }
+    // Wait for the filter pill to appear, confirming the filter was applied.
+    await expect(page.locator('[data-testid^="filter-pill-"]').first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // After excluding, matching rows should be hidden.
+    const filteredRows = await page.locator(WS.tableRow).count();
+    expect(filteredRows).toBeLessThanOrEqual(totalRows);
   });
 
   test.skip('table footer updates row count when filter is applied', async ({ page }) => {
@@ -307,15 +276,18 @@ test.describe('Table interactions — AC-8: filter pills', () => {
     await firstDataCell.click({ button: 'right' });
 
     const includeItem = page.getByRole('menuitem', { name: /include/i });
-    if (await includeItem.isVisible()) {
-      await includeItem.click();
-      await page.waitForTimeout(500);
+    await expect(includeItem).toBeVisible({ timeout: 5_000 });
+    await includeItem.click();
 
-      const footerAfter = await ws.table.footerText();
-      // Footer text should reflect the filtered count (may differ from total).
-      expect(footerAfter).toBeTruthy();
-      void footerBefore;
-    }
+    // Wait for the filter pill to appear before checking the footer.
+    await expect(page.locator('[data-testid^="filter-pill-"]').first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    const footerAfter = await ws.table.footerText();
+    // Footer text should reflect the filtered count (may differ from total).
+    expect(footerAfter).toBeTruthy();
+    void footerBefore;
   });
 });
 
@@ -349,12 +321,14 @@ test.describe('Table interactions — AC-9: view save and load', () => {
     // Apply a sort so there is state to save.
     const ws = new WorkspacePage(page);
     await ws.table.clickHeader('Name');
-    await page.waitForTimeout(300);
+    // Wait for the sort to take effect before saving.
+    const nameHeader = page.locator(WS.tableHeaderRow).filter({ hasText: /^name$/i });
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending', { timeout: 5_000 });
 
     await page.locator(WS.viewSaveButton).click();
 
     // The save action may open a dialog or save silently and show a toast.
-    // We check for either a dialog or a success notification.
+    // We check for either a dialog or a success notification (auto-retrying).
     const dialog = page.getByRole('dialog');
     const toast = page.locator('[role="status"]').filter({ hasText: /saved|success/i });
 
@@ -370,68 +344,67 @@ test.describe('Table interactions — AC-9: view save and load', () => {
 
     // Save the current default view.
     await page.locator(WS.viewSaveButton).click();
-    await page.waitForTimeout(1_000);
 
-    // Dismiss any save dialog.
+    // Dismiss any save dialog (auto-retrying: wait for button, then click).
     const confirmButton = page.getByRole('button', { name: /save|confirm|ok/i });
-    if (await confirmButton.isVisible()) {
+    if (await confirmButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
       await confirmButton.click();
-      await page.waitForTimeout(500);
     }
 
-    // Open the ViewSelector dropdown.
+    // Open the ViewSelector dropdown (must be present).
     const selectorTrigger = page.locator(WS.viewSelector);
-    if (await selectorTrigger.isVisible()) {
-      await selectorTrigger.click();
-      // There should be at least one view listed.
-      const viewEntries = page.locator('[data-active], [class*="entry"]');
-      const count = await viewEntries.count();
-      expect(count).toBeGreaterThan(0);
-    }
+    await expect(selectorTrigger).toBeVisible({ timeout: 5_000 });
+    await selectorTrigger.click();
+
+    // There should be at least one view listed (auto-retrying).
+    const viewEntries = page.locator('[data-active], [class*="entry"]');
+    await expect(viewEntries.first()).toBeVisible({ timeout: 5_000 });
   });
 
   test.skip('loading a saved view restores its sort state', async ({ page }) => {
     // Requires: docker compose up -d + database session (two-step test)
-    // Step 1: Sort, save the view.
-    // Step 2: Reload the page, load the saved view, verify sort is restored.
+    // Step 1: Sort by Name ascending, save the view.
+    // Step 2: Reload the page, load the saved view, verify the Name column
+    //         header still shows aria-sort="ascending" (not just rowCount > 0).
     await openTablePage(page);
 
     const ws = new WorkspacePage(page);
+    const nameHeader = page.locator(WS.tableHeaderRow).filter({ hasText: /^name$/i });
 
     // Sort by Name ascending.
     await ws.table.clickHeader('Name');
-    await page.waitForTimeout(300);
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending', { timeout: 5_000 });
 
     // Save the view.
     await page.locator(WS.viewSaveButton).click();
-    await page.waitForTimeout(500);
 
     const confirmButton = page.getByRole('button', { name: /save|confirm/i });
-    if (await confirmButton.isVisible()) {
+    if (await confirmButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
       await confirmButton.click();
-      await page.waitForTimeout(500);
     }
 
-    // Reload the workspace page.
+    // Reload the workspace page and navigate back to Contacts.
     await page.reload();
     await ws.waitForShell();
     await ws.sidebar.clickItem('Contacts');
     await page.locator(WS.tableContainer).waitFor({ state: 'visible', timeout: 10_000 });
 
-    // Load the saved view from the ViewSelector.
+    // Load the saved view from the ViewSelector (must be present).
     const selectorTrigger = page.locator(WS.viewSelector);
-    if (await selectorTrigger.isVisible()) {
-      await selectorTrigger.click();
-      const viewEntry = page.locator('[class*="entry"]').first();
-      if (await viewEntry.isVisible()) {
-        await viewEntry.click();
-        await page.waitForTimeout(500);
+    await expect(selectorTrigger).toBeVisible({ timeout: 5_000 });
+    await selectorTrigger.click();
 
-        // The table should still have rows (sort state loaded).
-        const rowCount = await page.locator(WS.tableRow).count();
-        expect(rowCount).toBeGreaterThan(0);
-      }
-    }
+    const viewEntry = page.locator('[class*="entry"]').first();
+    await expect(viewEntry).toBeVisible({ timeout: 5_000 });
+    await viewEntry.click();
+
+    // The Name column header must show the restored sort state (ascending).
+    // This verifies sort state is actually persisted, not just that rows exist.
+    await expect(page.locator(WS.tableHeaderRow).filter({ hasText: /^name$/i })).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+      { timeout: 5_000 },
+    );
   });
 
   test.skip('reset button restores the default view state', async ({ page }) => {
@@ -439,38 +412,37 @@ test.describe('Table interactions — AC-9: view save and load', () => {
     await openTablePage(page);
 
     const ws = new WorkspacePage(page);
+    const nameHeader = page.locator(WS.tableHeaderRow).filter({ hasText: /^name$/i });
 
     // Apply a sort change.
     await ws.table.clickHeader('Name');
-    await page.waitForTimeout(300);
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending', { timeout: 5_000 });
 
-    // Click reset if visible.
+    // Reset button must be present (fails test if missing).
     const resetButton = page.locator(WS.viewResetButton);
-    if (await resetButton.isVisible()) {
-      await resetButton.click();
-      await page.waitForTimeout(300);
+    await expect(resetButton).toBeVisible({ timeout: 5_000 });
+    await resetButton.click();
 
-      // After reset the table should still render rows.
-      const rowCount = await page.locator(WS.tableRow).count();
-      expect(rowCount).toBeGreaterThan(0);
-    }
+    // After reset the sort indicator should be gone (auto-retrying).
+    await expect(nameHeader).not.toHaveAttribute('aria-sort', /(ascending|descending)/, {
+      timeout: 5_000,
+    });
+    // Table must still render rows.
+    await expect(page.locator(WS.tableRow).first()).toBeVisible({ timeout: 5_000 });
   });
 
   test.skip('view selector shows MY VIEWS section for owned views', async ({ page }) => {
     // Requires: docker compose up -d + saved views for admin user
     await openTablePage(page);
 
+    // ViewSelector must be present (fails test if missing).
     const selectorTrigger = page.locator(WS.viewSelector);
-    if (await selectorTrigger.isVisible()) {
-      await selectorTrigger.click();
+    await expect(selectorTrigger).toBeVisible({ timeout: 5_000 });
+    await selectorTrigger.click();
 
-      // The MY VIEWS section header should appear.
-      const myViewsHeader = page.getByText(/my views/i);
-      // May not appear if no views are saved; just verify the dropdown opened.
-      const dropdown = page.locator('[class*="dropdown"]').first();
-      await expect(dropdown).toBeVisible({ timeout: 5_000 });
-      void myViewsHeader;
-    }
+    // The dropdown must open (auto-retrying).
+    const dropdown = page.locator('[class*="dropdown"]').first();
+    await expect(dropdown).toBeVisible({ timeout: 5_000 });
   });
 });
 
@@ -498,9 +470,8 @@ test.describe('Table interactions — accessibility', () => {
 
     // Press 'j' to move to the next row.
     await page.keyboard.press('j');
-    await page.waitForTimeout(100);
 
-    // The table should still be visible (no crash).
+    // The table should still be visible after the keypress (auto-retrying assertion).
     await expect(tableContainer).toBeVisible();
   });
 

--- a/packages/shell/e2e/workspace/workspace.spec.ts
+++ b/packages/shell/e2e/workspace/workspace.spec.ts
@@ -246,9 +246,10 @@ test.describe('Workspace — AC-3: open panel from sidebar', () => {
     await ws.sidebar.clickItem('Dashboard');
 
     const dashTabs = page.locator(WS.dockviewTab).filter({ hasText: 'Dashboard' });
-    // Should only exist once (or the panel store deduplicates).
+    // The panel store deduplicates: opening the same page twice must not
+    // create more than one tab. Exactly 1 is the expected and correct count.
     const count = await dashTabs.count();
-    expect(count).toBeLessThanOrEqual(2);
+    expect(count).toBe(1);
   });
 
   test.skip('panel content area renders after opening a page', async ({ page }) => {


### PR DESCRIPTION
Closes #184

## Summary

- Implements US-127: Playwright E2E tests for the full workspace surface across 4 subtasks (127a–127d).
- All tests that require Docker services (`docker compose up -d`) are marked `test.skip` with clear comments explaining prerequisites. Auth-protection tests run without Docker in the standard CI pipeline.

## Files changed

| File | Subtask | Purpose |
|------|---------|---------|
| `e2e/workspace/fixtures/workspace-page.ts` | 127a | Page Object Model (POM) for all workspace regions: sidebar, tray, command palette, mode switch, table, view toolbar |
| `e2e/workspace/fixtures/seed-data.ts` | 127a | In-memory constants mirroring DB seed data (users, pages, views, sample records) |
| `e2e/workspace/workspace.spec.ts` | 127b | AC-1 to AC-5: workspace load, sidebar toggle (click + Cmd+B), panel open from sidebar, multiple panels, tray minimize/restore |
| `e2e/workspace/command-palette.spec.ts` | 127c | AC-6: command palette open via Cmd+K and tray button, search, empty state, result selection, keyboard navigation, accessibility |
| `e2e/workspace/mode-switch.spec.ts` | 127c | AC-10: Editor/Builder toggle, RBAC visibility by role, per-panel mode isolation, accessibility |
| `e2e/workspace/table-interactions.spec.ts` | 127d | AC-7 to AC-9: table sort (header click, order, count stability), filter pills (context menu, row count, remove), view save/load (ViewToolbar, ViewSelector) |

## Acceptance criteria implemented

- AC-1: Workspace loads with sidebar + Dockview area
- AC-2: Sidebar toggle via click and Cmd+B
- AC-3: Open panel from sidebar, verify tab appears
- AC-4: Split panels, verify both visible
- AC-5: Minimize to tray, verify tray item, restore
- AC-6: Command palette opens, search, select, panel opens
- AC-7: Table sort — click header, verify order
- AC-8: Table filter — add pill, verify row count
- AC-9: View save/load — save, reload, verify state
- AC-10: Mode switch — toggle Editor/Builder

## Test plan

- [x] Auth-protection tests (no Docker) run via `pnpm test:e2e`
- [x] `pnpm lint` passes (E2E files are outside the `src/` lint scope and pass direct eslint check)
- [x] `pnpm typecheck` passes for the shell package
- [ ] Docker-required tests: `docker compose up -d && pnpm prisma:migrate && pnpm prisma:seed && pnpm test:e2e` (marked skip in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)