### PR TITLE
docs(phase-1b): add Phase 1B completion document

### DIFF
--- a/phases/phase-1b-final-baseline/completion.md
+++ b/phases/phase-1b-final-baseline/completion.md
@@ -1,0 +1,374 @@
+# Phase 1B: Page Templates + Builder Mode -- Completion Report
+
+> Completed: 2026-03-23 | Duration: ~2 days (estimated: 4 weeks)
+> Predecessor: Phase 1A (Workspace Infrastructure)
+
+## Summary
+
+Phase 1B delivered the complete page template system, builder mode, dashboard view, and all supporting infrastructure for the Vastu workspace. Starting from the Phase 1A workspace foundation (Dockview, VastuTable, view engine, filter system, context menus), this phase fixed 15 Phase 1A bugs, added 6 page templates, a charting component, command palette, keyboard shortcuts, confirmation dialogs, a record detail drawer, builder mode configuration panel, and a dashboard view with pinned cards. The phase concludes with comprehensive E2E test coverage across all workspace features.
+
+All 19 user stories (US-120 through US-138) and 1 infrastructure task (INFRA) were delivered across 6 waves, with 67 subtasks completed. Work was executed in strict dependency order: bug fixes first (Wave 0), then infrastructure components (Waves 1-2), then templates (Wave 3), then builder and dashboard (Wave 4), and finally E2E tests (Wave 5).
+
+**Key metrics:**
+
+| Metric | Count |
+|--------|-------|
+| User stories delivered | 19/19 + 1 INFRA |
+| Subtasks completed | 67 |
+| Merged PRs | 39 |
+| Files changed | 201 |
+| Lines added | ~33,400 |
+| Lines removed | ~380 |
+| Workspace source lines | ~27,500 |
+| Shell source lines (API routes + E2E) | ~2,050 |
+| Shared types lines | ~140 |
+| Unit/component test lines | ~9,660 |
+| E2E spec files (workspace) | 9 |
+| New components | 12 |
+| Page templates | 6 |
+| New Zustand stores | 2 (drawerStore, builderStore) |
+| Dependencies added | 3 (@mantine/form, @mantine/spotlight, recharts) |
+
+---
+
+## User story status
+
+| Story | Title | Wave | Status | Key files | Tests |
+|-------|-------|------|--------|-----------|-------|
+| US-120 | Mode switch rebuild | 0 | Complete | `ModeSwitch/`, `stores/panelStore.ts`, `DockviewHost/PanelTab.tsx` | `ModeSwitch.test.tsx` |
+| US-121 | View engine fixes | 0 | Complete | `stores/viewStore.ts`, `ViewToolbar/`, `shared/types/view.ts` | `viewStore.test.ts`, `ViewToolbar.test.tsx` |
+| US-122 | Filter system fixes | 0 | Complete | `FilterSystem/types.ts`, `FilterSystem/FilterBar.tsx`, `shared/types/view.ts` | `FilterBar.test.tsx`, `FilterPill.test.tsx` |
+| US-123 | Context menu fixes | 0 | Complete | `ContextMenu/ContextMenu.tsx`, `ContextMenu/ContextMenuItem.tsx` | `ContextMenu.test.tsx` |
+| US-124 | Design system compliance | 0 | Complete | `EmptyState/`, `SidebarNav/`, `VastuTable/` | `EmptyState.test.tsx` |
+| US-125 | Command palette | 1 | Complete | `CommandPalette/`, `hooks/useCommandPaletteActions.ts`, `TrayBar/` | `CommandPalette.test.tsx` |
+| US-126 | Keyboard shortcuts | 1 | Complete | `hooks/useKeyboardShortcuts.ts`, `ShortcutsModal/` | `useKeyboardShortcuts.test.ts`, `ShortcutsModal.test.tsx` |
+| US-127 | Workspace E2E tests | 5 | Complete | `e2e/workspace/` (9 spec files + fixtures) | E2E: workspace, sidebar, panels, command palette, mode switch, table, views |
+| US-128 | Record detail drawer | 2 | Complete | `RecordDrawer/`, `VastuTabs/`, `stores/drawerStore.ts`, API routes | `RecordDrawer.test.tsx`, `VastuTabs.test.tsx` |
+| US-129 | Table listing template | 3 | Complete | `templates/TableListing/`, `KPICard/` | `TableListingTemplate.test.tsx` |
+| US-130 | Summary dashboard template | 3 | Complete | `templates/SummaryDashboard/` | `SummaryDashboardTemplate.test.tsx` |
+| US-131 | Multi-tab detail template | 3 | Complete | `templates/MultiTabDetail/` | `MultiTabDetailTemplate.test.tsx` |
+| US-132 | Data explorer template | 3 | Complete | `templates/DataExplorer/` | `DataExplorerTemplate.test.tsx` |
+| US-133 | Form page template | 3 | Complete | `templates/FormPage/`, `useFormDraft.ts` | `FormPageTemplate.test.tsx` |
+| US-134 | Timeline/activity template | 3 | Complete | `templates/TimelineActivity/` | `TimelineActivityTemplate.test.tsx` |
+| US-135 | VastuChart wrapper | 1 | Complete | `VastuChart/`, `ChartTooltip.tsx`, `ChartLegend.tsx`, `ChartConfigPanel.tsx` | `VastuChart.test.tsx`, `ChartLegend.test.tsx` |
+| US-136 | Builder mode config panel | 4 | Complete | `BuilderPanel/`, `stores/builderStore.ts`, API config route | `BuilderPanel.test.tsx` |
+| US-137 | Dashboard view (pinned cards) | 4 | Complete | `templates/Dashboard/`, `stores/dashboardStore.ts` | `DashboardTemplate.test.tsx` |
+| US-138 | Confirmation dialog system | 1 | Complete | `ConfirmDialog/`, `useConfirmDialog.ts` | `ConfirmDialog.test.tsx` |
+| INFRA | Template infrastructure | 2 | Complete | `templates/types.ts`, `templates/registry.ts`, `templates/useTemplateConfig.ts`, `TemplateSkeleton.tsx` | `registry.test.ts`, `useTemplateConfig.test.ts` |
+
+---
+
+## Features delivered by wave
+
+### Wave 0: Phase 1A bug fixes (5 features, all parallel)
+
+Resolved 15 Phase 1A bugs across the view engine, filter system, context menus, mode switch, and design system. Key fixes:
+
+- **US-120**: Rewrote ModeSwitch from IER filter modes to Editor/Builder/Workflow panel modes with CASL-gated visibility
+- **US-121**: Fixed ViewState shape, modified indicator (goldenrod dot), saveView API, ViewToolbar wiring, and view delete confirmation
+- **US-122**: Aligned FilterNode type to Patterns Library spec, fixed FilterBar mode propagation, and context menu include/exclude
+- **US-123**: Added `role="menu"` with proper ARIA attributes, TruncatedText on menu item labels
+- **US-124**: Created shared EmptyState component, fixed SidebarUserAvatar tokens, audited all hex values and font weights
+
+### Wave 1: Infrastructure components (4 features, all parallel)
+
+Built the foundational components that templates and builder mode depend on:
+
+- **US-138**: ConfirmDialog with three variants (delete/warning/info) and useConfirmDialog imperative hook
+- **US-135**: VastuChart wrapping Recharts with 6 chart types (line, bar, area, donut, sparkline, scatter), custom tooltip, legend, and config panel
+- **US-125**: Command palette built on Mantine Spotlight with fuzzy search across pages, recent records, and commands
+- **US-126**: Global keyboard shortcuts (15+ bindings) with context-aware suppression and reference modal
+
+### Wave 2: Core features (2 features)
+
+- **US-128**: Record detail drawer with slide animation, prev/next navigation, 5 tabs (Details, Items, History, Notes, Permissions), sticky footer, drawer-to-panel promotion, and server API routes for CRUD/history/notes
+- **INFRA**: Template type system, registry pattern, useTemplateConfig hook, TemplateSkeleton loading component, PageConfiguration shared types, and API config route
+
+### Wave 3: Page templates (6 templates, all parallel)
+
+All templates registered in the panel registry, render in Dockview panels, consume configuration objects, and support zero-config first render:
+
+- **US-129**: Table listing template with KPI summary strip, VastuTable integration, row click to drawer, view toolbar
+- **US-130**: Summary dashboard with time range control, KPI cards with delta/sparkline, chart rows, mini summary tables
+- **US-131**: Multi-tab detail with entity header, RBAC-gated tabs, overview two-column layout, sub-tables, activity timeline
+- **US-132**: Data explorer with metric/dimension/time controls, chart type toggle, companion data table, export (PNG/CSV)
+- **US-133**: Form page with single-page and multi-step wizard modes, search-or-create pattern, auto-save drafts, dirty state detection
+- **US-134**: Timeline/activity with date-grouped event stream, type-colored dots, expandable detail, infinite scroll, type/date/user filters
+
+### Wave 4: Builder mode and dashboard (2 features, parallel)
+
+- **US-136**: Builder mode config panel with 8 configuration sections (data source, field config, sections/layout, default view, permissions, hooks, page metadata, ephemeral toggle), warning header, discard/save actions, audit trail
+- **US-137**: Dashboard view with greeting header, responsive card grid (6 card types: KPI, chart, table, pipeline, quick actions, alert), edit grid mode with drag-to-reorder, add card dialog, pin-to-dashboard dialog
+
+### Wave 5: E2E testing (1 feature)
+
+- **US-127**: 9 Playwright E2E spec files covering workspace load, sidebar navigation, panel management, tray bar, command palette, mode switch, table interactions (sort/filter/pagination), view save/load, builder mode, and dashboard view
+
+---
+
+## Architecture decisions
+
+### ADR-007: Template registry pattern
+- Templates registered via a central `registry.ts` that maps template type strings to React components
+- Panel registry imports from template registry for Dockview panel creation
+- Templates receive configuration via `useTemplateConfig` hook that reads from `page_configurations` table
+- All templates render with sensible defaults when no configuration exists (zero-config)
+
+### ADR-008: VastuChart as the sole charting abstraction
+- All charts go through `VastuChart` -- never raw Recharts
+- Automatic color assignment from `CHART_SERIES_COLORS` palette in deterministic order
+- Custom HTML tooltip and legend components replace Recharts defaults for design system compliance
+- Collapsible ChartConfigPanel for basic and advanced chart settings
+
+### ADR-009: Drawer-to-panel promotion
+- RecordDrawer and Dockview panels share the same content component tree
+- `useDrawerToPanel` hook handles promotion: drawer slides out, new Dockview tab opens, scroll position and active tab preserved
+- drawerStore (Zustand) manages drawer state, navigation queue, and record references
+
+### ADR-010: Builder mode config storage
+- Page configuration stored as JSON in `page_configurations` table (Prisma)
+- Configuration is runtime -- takes effect immediately on save, no deployment needed
+- Every config save writes an audit event for traceability
+- builderStore (Zustand) manages in-flight edits with dirty state detection and discard/save actions
+- Hook editor UI included (Monaco) but hook execution deferred to Phase 3
+
+### ADR-011: Dashboard card grid
+- CSS Grid with `grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))` for responsive columns
+- HTML5 Drag API for card reorder in edit mode (no external drag-and-drop library)
+- dashboardStore (Zustand) manages card positions, sizes, and configuration
+- Cards can be pinned from any view via PinToDashboardDialog
+
+### ADR-012: E2E test architecture for workspace
+- Page object pattern: `WorkspacePage` fixture class encapsulates all workspace interactions
+- Tests run against the development server with seed data
+- Workspace E2E tests placed under `packages/shell/e2e/workspace/` alongside existing auth/admin/settings E2E suites
+- Each spec file covers a distinct feature domain for parallel execution
+
+---
+
+## Design system compliance
+
+| Requirement | Status |
+|-------------|--------|
+| All colors via `--v-*` tokens | Yes -- audited in US-124, no hardcoded hex values |
+| TruncatedText on truncatable text | Yes -- context menus, sidebar items, table cells, drawer fields |
+| Loading states (skeleton -> content -> error) | Yes -- TemplateSkeleton for all templates, per-card/chart skeletons |
+| EmptyState component | Yes -- shared EmptyState with contextual message and action |
+| Two font weights only (400/500) | Yes -- audited in US-124 |
+| Toast notifications | Yes -- consistent with Phase 0 pattern |
+| WCAG 2.2 AA | Partial -- aria-labels on icon-only buttons, role="menu" on context menus, keyboard navigation, focus management |
+| Keyboard navigation | Yes -- global shortcuts, table-specific shortcuts, focus ring on keyboard only |
+| Context menus | Yes -- portal rendering, ARIA roles, TruncatedText labels |
+| Confirmation dialogs | Yes -- ConfirmDialog on all destructive actions |
+| Chart accessibility | Partial -- aria-label describing chart, "View as table" toggle available on data explorer |
+
+---
+
+## Test coverage
+
+### Unit and component tests (Vitest)
+
+New test files added in Phase 1B:
+
+- `ModeSwitch/__tests__/ModeSwitch.test.tsx`
+- `ViewToolbar/__tests__/ViewToolbar.test.tsx`
+- `stores/__tests__/viewStore.test.ts`
+- `FilterSystem/__tests__/FilterBar.test.tsx`, `FilterPill.test.tsx`
+- `ContextMenu/__tests__/ContextMenu.test.tsx`
+- `EmptyState/__tests__/EmptyState.test.tsx`
+- `ConfirmDialog/__tests__/ConfirmDialog.test.tsx`
+- `VastuChart/__tests__/VastuChart.test.tsx`, `ChartLegend.test.tsx`
+- `CommandPalette/__tests__/CommandPalette.test.tsx`
+- `ShortcutsModal/__tests__/ShortcutsModal.test.tsx`
+- `hooks/__tests__/useKeyboardShortcuts.test.ts`
+- `RecordDrawer/__tests__/RecordDrawer.test.tsx`
+- `VastuTabs/__tests__/VastuTabs.test.tsx`
+- `templates/__tests__/registry.test.ts`, `useTemplateConfig.test.ts`
+- `templates/TableListing/__tests__/TableListingTemplate.test.tsx`
+- `templates/SummaryDashboard/__tests__/SummaryDashboardTemplate.test.tsx`
+- `templates/MultiTabDetail/__tests__/MultiTabDetailTemplate.test.tsx`
+- `templates/DataExplorer/__tests__/DataExplorerTemplate.test.tsx`
+- `templates/FormPage/__tests__/FormPageTemplate.test.tsx`
+- `templates/TimelineActivity/__tests__/TimelineActivityTemplate.test.tsx`
+- `BuilderPanel/__tests__/BuilderPanel.test.tsx`
+- `templates/Dashboard/__tests__/DashboardTemplate.test.tsx`
+
+Total: ~9,660 lines of test code added.
+
+### E2E tests (Playwright): 9 workspace spec files
+
+- `workspace.spec.ts` -- workspace load, sidebar, Dockview area
+- `sidebar-nav.spec.ts` -- sidebar toggle, collapsed/expanded
+- `workspace-layout.spec.ts` -- panel open, split, layout
+- `command-palette.spec.ts` -- open, search, select result
+- `mode-switch.spec.ts` -- toggle Editor/Builder, content swap
+- `table-interactions.spec.ts` -- sort, filter, pagination, row selection
+- `view-store.spec.ts` -- save, load, reset views
+- `builder-mode.spec.ts` -- builder panel, config sections, save
+- `dashboard-view.spec.ts` -- card grid, add/remove cards, edit mode
+
+---
+
+## New components inventory
+
+| Component | Package | Purpose |
+|-----------|---------|---------|
+| ModeSwitch | workspace | Editor/Builder/Workflow panel mode selector |
+| EmptyState | workspace | Shared empty state with icon, message, and action |
+| ConfirmDialog | workspace | Confirmation dialog with delete/warning/info variants |
+| VastuChart | workspace | Recharts wrapper with design system compliance |
+| CommandPalette | workspace | Global search and command overlay (Mantine Spotlight) |
+| ShortcutsModal | workspace | Keyboard shortcuts reference overlay |
+| RecordDrawer | workspace | Slide-out record detail with 5 tabs |
+| VastuTabs | workspace | Shared tab component extracted from RecordDrawer |
+| KPICard | workspace | Metric card with value, delta, and optional sparkline |
+| BuilderPanel | workspace | Page configuration panel with 8 sections |
+| TemplateSkeleton | workspace | Loading skeleton for template panels |
+| PinToDashboardDialog | workspace | Dialog for pinning views to dashboard |
+
+## Page templates inventory
+
+| Template | Registry key | Features |
+|----------|-------------|----------|
+| TableListingTemplate | `table-listing` | VastuTable, KPI strip, filters, views, row click to drawer |
+| SummaryDashboardTemplate | `summary-dashboard` | Time range, KPI cards, charts, mini tables |
+| MultiTabDetailTemplate | `multi-tab-detail` | Entity header, RBAC-gated tabs, sub-tables, activity |
+| DataExplorerTemplate | `data-explorer` | Metric/dimension controls, chart toggle, companion table, export |
+| FormPageTemplate | `form-page` | Single-page, wizard, search-or-create, auto-save drafts |
+| TimelineActivityTemplate | `timeline-activity` | Date-grouped events, type filters, expandable detail, infinite scroll |
+| DashboardTemplate | `dashboard` | Greeting, card grid (6 types), edit mode, pin-to-dashboard |
+
+---
+
+## Dependencies added
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@mantine/form` | ^7.14.3 | Form validation for FormPageTemplate and BuilderPanel |
+| `@mantine/spotlight` | ^7.17.8 | Command palette overlay component |
+| `recharts` | ^3.8.0 | Charting library wrapped by VastuChart |
+
+---
+
+## Zustand stores added
+
+| Store | File | Purpose |
+|-------|------|---------|
+| drawerStore | `stores/drawerStore.ts` | Record drawer state, navigation queue, active record |
+| builderStore | `stores/builderStore.ts` | Builder mode in-flight config edits, dirty state, save/discard |
+| dashboardStore | `stores/dashboardStore.ts` | Dashboard card positions, sizes, configuration, edit mode |
+
+---
+
+## API routes added
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/workspace/records/[id]` | GET/PUT/DELETE | Record CRUD operations |
+| `/api/workspace/records/[id]/history` | GET | Record audit history |
+| `/api/workspace/records/[id]/notes` | GET/POST | Record notes management |
+| `/api/workspace/pages/[id]/config` | GET/PUT | Page configuration (builder mode) |
+
+---
+
+## Known issues and technical debt
+
+1. **Hook execution is UI-only:** Builder mode includes the hooks section with Monaco editor, but hook execution is deferred to Phase 3. The UI stores hook code in the config; a placeholder message shows in the execution area.
+
+2. **Object permission editor is UI-only:** The RecordDrawer Permissions tab allows setting per-object ACLs but does not enforce row-level security on queries. Enforcement comes in Phase 2.
+
+3. **Templates use mock/seed data:** All page templates render with mock data and Prisma seed data. Real external database queries via configured connections are Phase 2.
+
+4. **Chart accessibility is partial:** VastuChart has aria-labels and "View as table" toggle on data explorer, but keyboard-navigable data points are not fully implemented across all chart types.
+
+5. **Dashboard drag-to-reorder uses HTML5 Drag API:** Works on desktop browsers but may have issues on touch devices. Consider adding touch fallback or a drag-and-drop library if mobile support becomes a priority.
+
+6. **E2E tests run against development server:** Workspace E2E tests require the full development stack (Postgres, Redis, etc.) to be running. CI configuration for these tests needs Docker Compose setup similar to existing auth E2E suites.
+
+7. **Auto-refresh on summary dashboard:** Toggle exists but interval-based refetching is not connected to a real data polling mechanism. Will need WebSocket or SSE integration in Phase 2.
+
+---
+
+## What was deferred (out of scope)
+
+| Item | Deferred to | Notes |
+|------|-------------|-------|
+| Workflow mode content | Phase 2 | ModeSwitch shows the tab; placeholder content renders |
+| Agent panel / AG-UI | Phase 2 | Not started |
+| Hook execution engine | Phase 3 | UI exists in builder; execution sandboxing is Phase 3 |
+| MCP tools for workspace | Phase 2 | Not started |
+| Real external DB queries | Phase 2 | Templates use mock data |
+| OpenTelemetry / monitoring | Phase 3 | Not started |
+| Notification subsystem | Phase 2 | Beyond toasts |
+| Row-level security enforcement | Phase 2 | Permissions tab UI exists |
+| Fumadocs updates | Deferred | Template usage guide, API docs not written |
+
+---
+
+## Bugs closed from Phase 1A
+
+| Bug | Issue | Fixed in |
+|-----|-------|----------|
+| IER filter mode switch instead of Editor/Builder/Workflow | #136 | US-120 |
+| ViewState shape missing fields | #124 | US-121 |
+| Modified indicator not implemented | #125 | US-121 |
+| saveView API requires undocumented parameter | #126 | US-121 |
+| ViewToolbar not wired to WorkspaceShell | #141 | US-121 |
+| "New View" does not reset state | #142 | US-121 |
+| Reset control hidden instead of disabled | #143 | US-121 |
+| View delete has no confirmation | #144 | US-121 |
+| FilterNode type deviates from spec | #123 | US-122 |
+| FilterBar mode not propagating | #138 | US-122 |
+| Context menu include/exclude same mode value | #160 | US-122 |
+| Context menu missing role="menu" | #139 | US-123 |
+| Context menu labels not using TruncatedText | #140 | US-123 |
+| SidebarUserAvatar hardcoded color | #114 | US-124 |
+| SidebarItem labels not truncated | #115 | US-124 |
+| VastuTable inline empty state | #161 | US-124 |
+
+---
+
+## Merged PRs
+
+39 PRs merged to main during Phase 1B, including:
+
+| PR | Title |
+|----|-------|
+| #255 | chore: initialize Phase 1B baseline |
+| #257 | test(workspace): context menu ARIA and TruncatedText verification [VASTU-1B-123] |
+| #259 | feat(workspace): design system compliance sweep [VASTU-1B-124] |
+| #260 | feat(workspace): align FilterNode type to spec and fix mode propagation [VASTU-1B-122] |
+| #261 | feat(workspace): rebuild ModeSwitch for Editor/Builder/Workflow [VASTU-1B-120] |
+| #265 | feat(workspace): view engine fixes [VASTU-1B-121] |
+| #271 | feat(workspace): add VastuChart Recharts wrapper with 6 chart types [VASTU-1B-135] |
+| #272 | feat(workspace): confirmation dialog system with useConfirmDialog hook [VASTU-1B-138] |
+| #273 | feat(workspace): global keyboard shortcuts and reference modal [VASTU-1B-126] |
+| #274 | feat(workspace): command palette with Mantine Spotlight [VASTU-1B-125] |
+| #275 | feat(workspace): template infrastructure [VASTU-1B-INFRA] |
+| #280 | feat(workspace): record detail drawer with API routes [VASTU-1B-128] |
+| #287 | feat(workspace): add data explorer template [VASTU-1B-132] |
+| #288 | feat(workspace): add table listing template with KPI summary strip [VASTU-1B-129] |
+| #289 | feat(workspace): add multi-tab detail template [VASTU-1B-131] |
+| #290 | feat(workspace): add form page template with wizard and auto-save [VASTU-1B-133] |
+| #302 | feat(workspace): add timeline/activity template [VASTU-1B-134] |
+| #303 | feat(workspace): add summary dashboard template [VASTU-1B-130] |
+| #304 | feat(workspace): add builder mode config panel [VASTU-1B-136] |
+| #305 | feat(workspace): add dashboard view with pinned cards [VASTU-1B-137] |
+| #317 | test(workspace): add workspace E2E tests [VASTU-1B-127] |
+
+(Plus 18 additional review-finding fix PRs and infrastructure PRs.)
+
+---
+
+## Recommendations for Phase 2
+
+1. **Connect templates to real data sources:** Replace mock data with queries through configured database connections from Phase 0.
+2. **Implement hook execution engine:** Builder mode hook UI is complete; Phase 3 needs sandboxed execution.
+3. **Add WebSocket/SSE for live updates:** Dashboard auto-refresh and timeline real-time events need server-push.
+4. **Enforce row-level security:** Wire the Permissions tab ACL editor to CASL query filters on API routes.
+5. **Write Fumadocs documentation:** Template usage guide, VastuChart API, builder mode guide, and filter system API docs were deferred.
+6. **Add CI workflow for workspace E2E:** Configure Docker Compose in GitHub Actions for the workspace E2E test suite.
+7. **Improve chart keyboard navigation:** Complete keyboard-navigable data points for all chart types.
+8. **Consider touch-friendly drag-and-drop:** Dashboard card reorder may need a library (e.g., dnd-kit) for mobile support.
+9. **Workflow mode implementation:** ModeSwitch and panel infrastructure are ready; workflow content is the next major feature.
+10. **Agent panel and AG-UI protocols:** The workspace panel system is extensible; agent runtime integration can begin.

--- a/phases/phase-1b-final-baseline/todo.md
+++ b/phases/phase-1b-final-baseline/todo.md
@@ -1,8 +1,9 @@
 # Phase 1B: Page Templates + Builder Mode -- Todo
 
 > Created: 2026-03-21
-> Status: IN PROGRESS
-> Total: 19 features + 1 infra task, 67 subtasks
+> Completed: 2026-03-23
+> Status: COMPLETE
+> Total: 19 features + 1 infra task, 67 subtasks (all done)
 > User stories: US-120 through US-138
 
 ---
@@ -62,11 +63,11 @@ Branch: `feature/VASTU-1B-120-mode-switch-rebuild`
 Package: workspace | Agent: design-engineer + dev-engineer | Est: ~390 lines
 Closes: #136
 
-- [ ] VASTU-1B-120a: Rewrite ModeSwitch component for Editor/Builder/Workflow modes (workspace, M) [no deps] -- #185
+- [x] VASTU-1B-120a: Rewrite ModeSwitch component for Editor/Builder/Workflow modes (workspace, M) [no deps] -- #185
   - Files: `ModeSwitch.tsx`, `ModeSwitch.module.css`, `types/panel.ts`
-- [ ] VASTU-1B-120b: Add panelModes to panelStore and wire to PanelTab (workspace, S) [deps: 120a] -- #186
+- [x] VASTU-1B-120b: Add panelModes to panelStore and wire to PanelTab (workspace, S) [deps: 120a] -- #186
   - Files: `stores/panelStore.ts`, `DockviewHost/PanelTab.tsx`
-- [ ] VASTU-1B-120c: ModeSwitch unit and component tests (workspace, M) [deps: 120a, 120b] -- #187
+- [x] VASTU-1B-120c: ModeSwitch unit and component tests (workspace, M) [deps: 120a, 120b] -- #187
   - Files: `ModeSwitch/__tests__/ModeSwitch.test.tsx`
 
 ---
@@ -76,13 +77,13 @@ Branch: `feature/VASTU-1B-121-view-engine-fixes`
 Package: workspace, shared | Agent: dev-engineer + design-engineer | Est: ~240 lines
 Closes: #124, #125, #126, #141, #142, #143, #144
 
-- [ ] VASTU-1B-121a: Fix ViewState shape and viewStore saveView/resetView (shared+workspace, S) [no deps] -- #188
+- [x] VASTU-1B-121a: Fix ViewState shape and viewStore saveView/resetView (shared+workspace, S) [no deps] -- #188
   - Files: `shared/types/view.ts`, `stores/viewStore.ts`
-- [ ] VASTU-1B-121b: Fix ViewToolbar wiring, modified indicator, reset button (workspace, S) [deps: 121a] -- #189
+- [x] VASTU-1B-121b: Fix ViewToolbar wiring, modified indicator, reset button (workspace, S) [deps: 121a] -- #189
   - Files: `ViewToolbar/ViewToolbar.tsx`, `ViewToolbar.module.css`, `WorkspaceShell.tsx`
-- [ ] VASTU-1B-121c: Add view delete confirmation dialog in ViewSelector (workspace, S) [deps: 121a] -- #190
+- [x] VASTU-1B-121c: Add view delete confirmation dialog in ViewSelector (workspace, S) [deps: 121a] -- #190
   - Files: `ViewToolbar/ViewSelector.tsx`
-- [ ] VASTU-1B-121d: View engine fix tests (workspace, M) [deps: 121a, 121b, 121c] -- #191
+- [x] VASTU-1B-121d: View engine fix tests (workspace, M) [deps: 121a, 121b, 121c] -- #191
   - Files: `stores/__tests__/viewStore.test.ts`, `ViewToolbar/__tests__/ViewToolbar.test.tsx`
 
 ---
@@ -92,11 +93,11 @@ Branch: `feature/VASTU-1B-122-filter-system-fixes`
 Package: workspace, shared | Agent: dev-engineer | Est: ~145 lines
 Closes: #123, #138, #160
 
-- [ ] VASTU-1B-122a: Align FilterNode type to Patterns Library spec + runtime normalization (shared+workspace, M) [no deps] -- #192
+- [x] VASTU-1B-122a: Align FilterNode type to Patterns Library spec + runtime normalization (shared+workspace, M) [no deps] -- #192
   - Files: `shared/types/view.ts`, `stores/viewStore.ts`, `FilterSystem/types.ts`
-- [ ] VASTU-1B-122b: Fix FilterBar mode propagation and context menu include/exclude (workspace, S) [deps: 122a] -- #193
+- [x] VASTU-1B-122b: Fix FilterBar mode propagation and context menu include/exclude (workspace, S) [deps: 122a] -- #193
   - Files: `FilterSystem/FilterBar.tsx`, `VastuTable/VastuTable.tsx`
-- [ ] VASTU-1B-122c: Update all filter tests for corrected FilterNode schema (workspace, M) [deps: 122a, 122b] -- #194
+- [x] VASTU-1B-122c: Update all filter tests for corrected FilterNode schema (workspace, M) [deps: 122a, 122b] -- #194
   - Files: `FilterSystem/__tests__/FilterBar.test.tsx`, `FilterSystem/__tests__/FilterPill.test.tsx`, `stores/__tests__/viewStore.test.ts`
 
 ---
@@ -106,7 +107,7 @@ Branch: `feature/VASTU-1B-123-context-menu-fixes`
 Package: workspace | Agent: dev-engineer | Est: ~30 lines
 Closes: #139, #140
 
-- [ ] VASTU-1B-123a: Verify and fix context menu ARIA role and TruncatedText usage (workspace, S) [no deps] -- #195
+- [x] VASTU-1B-123a: Verify and fix context menu ARIA role and TruncatedText usage (workspace, S) [no deps] -- #195
   - Files: `ContextMenu/ContextMenu.tsx`, `ContextMenu/ContextMenuItem.tsx`, `ContextMenu/__tests__/ContextMenu.test.tsx`
 
 ---
@@ -116,13 +117,13 @@ Branch: `feature/VASTU-1B-124-design-system-sweep`
 Package: workspace | Agent: design-engineer | Est: ~265 lines
 Closes: #114, #115, #161
 
-- [ ] VASTU-1B-124a: Create EmptyState shared component (workspace, M) [no deps] -- #196
+- [x] VASTU-1B-124a: Create EmptyState shared component (workspace, M) [no deps] -- #196
   - Files: `EmptyState/EmptyState.tsx`, `EmptyState/EmptyState.module.css`, `EmptyState/__tests__/EmptyState.test.tsx`
-- [ ] VASTU-1B-124b: Fix SidebarUserAvatar token and SidebarItem TruncatedText (workspace, S) [no deps, parallel with 124a] -- #197
+- [x] VASTU-1B-124b: Fix SidebarUserAvatar token and SidebarItem TruncatedText (workspace, S) [no deps, parallel with 124a] -- #197
   - Files: `SidebarNav/SidebarUserAvatar.tsx`, `SidebarNav/SidebarItem.tsx`
-- [ ] VASTU-1B-124c: Replace VastuTable inline empty state with EmptyState component (workspace, S) [deps: 124a] -- #198
+- [x] VASTU-1B-124c: Replace VastuTable inline empty state with EmptyState component (workspace, S) [deps: 124a] -- #198
   - Files: `VastuTable/VastuTable.tsx`
-- [ ] VASTU-1B-124d: Design system audit: hex values, font weights, aria-labels (workspace, S) [no deps, parallel with 124a] -- #199
+- [x] VASTU-1B-124d: Design system audit: hex values, font weights, aria-labels (workspace, S) [no deps, parallel with 124a] -- #199
   - Files: All `.tsx` and `.css` files in workspace (audit + fix)
 
 ---
@@ -131,11 +132,11 @@ Closes: #114, #115, #161
 Branch: `feature/VASTU-1B-138-confirm-dialog` (branch from main AFTER Wave 0 merges)
 Package: workspace | Agent: design-engineer + dev-engineer | Est: ~320 lines
 
-- [ ] VASTU-1B-138a: Create ConfirmDialog component with three variants (workspace, M) [no deps] -- #200
+- [x] VASTU-1B-138a: Create ConfirmDialog component with three variants (workspace, M) [no deps] -- #200
   - Files: `ConfirmDialog/ConfirmDialog.tsx`, `ConfirmDialog/ConfirmDialog.module.css`
-- [ ] VASTU-1B-138b: Create useConfirmDialog hook for imperative usage (workspace, M) [deps: 138a] -- #201
+- [x] VASTU-1B-138b: Create useConfirmDialog hook for imperative usage (workspace, M) [deps: 138a] -- #201
   - Files: `ConfirmDialog/useConfirmDialog.ts`, `WorkspaceShell.tsx`
-- [ ] VASTU-1B-138c: ConfirmDialog tests (workspace, M) [deps: 138a, 138b] -- #202
+- [x] VASTU-1B-138c: ConfirmDialog tests (workspace, M) [deps: 138a, 138b] -- #202
   - Files: `ConfirmDialog/__tests__/ConfirmDialog.test.tsx`
 
 ---
@@ -144,15 +145,15 @@ Package: workspace | Agent: design-engineer + dev-engineer | Est: ~320 lines
 Branch: `feature/VASTU-1B-135-vastu-chart` (branch from main AFTER Wave 0 merges)
 Package: workspace | Agent: dev-engineer + design-engineer | Est: ~1370 lines
 
-- [ ] VASTU-1B-135a: VastuChart types, color palette, and base component setup (workspace, M) [no deps] -- #203
+- [x] VASTU-1B-135a: VastuChart types, color palette, and base component setup (workspace, M) [no deps] -- #203
   - Files: `VastuChart/types.ts`, `VastuChart/chartColors.ts`, `VastuChart/VastuChart.tsx`, `VastuChart/VastuChart.module.css`, `package.json`
-- [ ] VASTU-1B-135b: VastuChart chart type renderers (line, bar, area, donut, sparkline, scatter) (workspace, L) [deps: 135a] -- #204
+- [x] VASTU-1B-135b: VastuChart chart type renderers (line, bar, area, donut, sparkline, scatter) (workspace, L) [deps: 135a] -- #204
   - Files: `VastuChart/VastuChart.tsx`
-- [ ] VASTU-1B-135c: ChartTooltip and ChartLegend custom components (workspace, M) [deps: 135a] -- #205
+- [x] VASTU-1B-135c: ChartTooltip and ChartLegend custom components (workspace, M) [deps: 135a] -- #205
   - Files: `VastuChart/ChartTooltip.tsx`, `VastuChart/ChartLegend.tsx`
-- [ ] VASTU-1B-135d: ChartConfigPanel collapsible configuration (workspace, L) [deps: 135a] -- #206
+- [x] VASTU-1B-135d: ChartConfigPanel collapsible configuration (workspace, L) [deps: 135a] -- #206
   - Files: `VastuChart/ChartConfigPanel.tsx`
-- [ ] VASTU-1B-135e: VastuChart tests (workspace, L) [deps: 135b, 135c, 135d] -- #207
+- [x] VASTU-1B-135e: VastuChart tests (workspace, L) [deps: 135b, 135c, 135d] -- #207
   - Files: `VastuChart/__tests__/VastuChart.test.tsx`, `VastuChart/__tests__/ChartLegend.test.tsx`
 
 ---
@@ -162,11 +163,11 @@ Branch: `feature/VASTU-1B-125-command-palette` (branch from main AFTER Wave 0 me
 Package: workspace | Agent: design-engineer + dev-engineer | Est: ~530 lines
 Continues: #93
 
-- [ ] VASTU-1B-125a: CommandPalette with Mantine Spotlight integration (workspace, M) [no deps] -- #208
+- [x] VASTU-1B-125a: CommandPalette with Mantine Spotlight integration (workspace, M) [no deps] -- #208
   - Files: `CommandPalette/CommandPalette.tsx`, `CommandPalette/CommandPalette.module.css`, `WorkspaceShell.tsx`, `package.json`
-- [ ] VASTU-1B-125b: CommandPaletteResult rendering and useCommandPaletteActions hook (workspace, M) [deps: 125a] -- #209
+- [x] VASTU-1B-125b: CommandPaletteResult rendering and useCommandPaletteActions hook (workspace, M) [deps: 125a] -- #209
   - Files: `CommandPalette/CommandPaletteResult.tsx`, `hooks/useCommandPaletteActions.ts`, `TrayBar/TrayBar.tsx`
-- [ ] VASTU-1B-125c: CommandPalette keyboard navigation and tests (workspace, M) [deps: 125a, 125b] -- #210
+- [x] VASTU-1B-125c: CommandPalette keyboard navigation and tests (workspace, M) [deps: 125a, 125b] -- #210
   - Files: `CommandPalette/__tests__/CommandPalette.test.tsx`
 
 ---
@@ -176,13 +177,13 @@ Branch: `feature/VASTU-1B-126-keyboard-shortcuts` (branch from main AFTER Wave 0
 Package: workspace | Agent: dev-engineer + design-engineer | Est: ~650 lines
 Continues: #94
 
-- [ ] VASTU-1B-126a: Create useKeyboardShortcuts hook with global registrations (workspace, M) [no deps] -- #211
+- [x] VASTU-1B-126a: Create useKeyboardShortcuts hook with global registrations (workspace, M) [no deps] -- #211
   - Files: `hooks/useKeyboardShortcuts.ts`, `WorkspaceShell.tsx`
-- [ ] VASTU-1B-126b: Create ShortcutsModal reference overlay (workspace, M) [deps: 126a] -- #212
+- [x] VASTU-1B-126b: Create ShortcutsModal reference overlay (workspace, M) [deps: 126a] -- #212
   - Files: `ShortcutsModal/ShortcutsModal.tsx`, `ShortcutsModal/ShortcutsModal.module.css`
-- [ ] VASTU-1B-126c: Table-specific keyboard shortcuts and focus management (workspace, S) [deps: 126a] -- #213
+- [x] VASTU-1B-126c: Table-specific keyboard shortcuts and focus management (workspace, S) [deps: 126a] -- #213
   - Files: `VastuTable/VastuTable.tsx`
-- [ ] VASTU-1B-126d: Keyboard shortcuts tests (workspace, M) [deps: 126a, 126b, 126c] -- #214
+- [x] VASTU-1B-126d: Keyboard shortcuts tests (workspace, M) [deps: 126a, 126b, 126c] -- #214
   - Files: `hooks/__tests__/useKeyboardShortcuts.test.ts`, `ShortcutsModal/__tests__/ShortcutsModal.test.tsx`
 
 ---
@@ -191,19 +192,19 @@ Continues: #94
 Branch: `feature/VASTU-1B-128-record-drawer` (branch from main AFTER Wave 1 merges)
 Package: workspace, shell | Agent: dev-engineer + design-engineer | Est: ~1540 lines
 
-- [ ] VASTU-1B-128a: Create drawerStore and RecordDrawer shell with slide animation (workspace, M) [no deps] -- #215
+- [x] VASTU-1B-128a: Create drawerStore and RecordDrawer shell with slide animation (workspace, M) [no deps] -- #215
   - Files: `stores/drawerStore.ts`, `RecordDrawer/RecordDrawer.tsx`, `RecordDrawer/RecordDrawer.module.css`
-- [ ] VASTU-1B-128b: RecordDrawerHeader with navigation and actions (workspace, M) [deps: 128a] -- #216
+- [x] VASTU-1B-128b: RecordDrawerHeader with navigation and actions (workspace, M) [deps: 128a] -- #216
   - Files: `RecordDrawer/RecordDrawerHeader.tsx`
-- [ ] VASTU-1B-128c: RecordDrawer tabs: Details and Items + VastuTabs wrapper (workspace, L) [deps: 128a] -- #217
+- [x] VASTU-1B-128c: RecordDrawer tabs: Details and Items + VastuTabs wrapper (workspace, L) [deps: 128a] -- #217
   - Files: `RecordDrawer/tabs/DetailsTab.tsx`, `RecordDrawer/tabs/ItemsTab.tsx`, `VastuTabs/VastuTabs.tsx`
-- [ ] VASTU-1B-128d: RecordDrawer tabs: History, Notes, Permissions (workspace, L) [deps: 128a] -- #218
+- [x] VASTU-1B-128d: RecordDrawer tabs: History, Notes, Permissions (workspace, L) [deps: 128a] -- #218
   - Files: `RecordDrawer/tabs/HistoryTab.tsx`, `RecordDrawer/tabs/NotesTab.tsx`, `RecordDrawer/tabs/PermissionsTab.tsx`
-- [ ] VASTU-1B-128e: RecordDrawerFooter and drawer-to-panel promotion (workspace, M) [deps: 128a, 128b] -- #219
+- [x] VASTU-1B-128e: RecordDrawerFooter and drawer-to-panel promotion (workspace, M) [deps: 128a, 128b] -- #219
   - Files: `RecordDrawer/RecordDrawerFooter.tsx`, `hooks/useDrawerToPanel.ts`
-- [ ] VASTU-1B-128f: Record API routes (CRUD, history, notes) (shell, M) [no deps, parallel with 128a] -- #220
+- [x] VASTU-1B-128f: Record API routes (CRUD, history, notes) (shell, M) [no deps, parallel with 128a] -- #220
   - Files: `api/workspace/records/[id]/route.ts`, `api/workspace/records/[id]/history/route.ts`, `api/workspace/records/[id]/notes/route.ts`
-- [ ] VASTU-1B-128g: RecordDrawer tests (workspace, L) [deps: 128b, 128c, 128d, 128e] -- #221
+- [x] VASTU-1B-128g: RecordDrawer tests (workspace, L) [deps: 128b, 128c, 128d, 128e] -- #221
   - Files: `RecordDrawer/__tests__/RecordDrawer.test.tsx`, `VastuTabs/__tests__/VastuTabs.test.tsx`
 
 ---
@@ -212,7 +213,7 @@ Package: workspace, shell | Agent: dev-engineer + design-engineer | Est: ~1540 l
 Branch: `feature/VASTU-1B-INFRA-template-infra` (branch from main AFTER Wave 0 merges, can start with Wave 1)
 Package: workspace, shared, shell | Agent: dev-engineer | Est: ~410 lines
 
-- [ ] VASTU-1B-INFRA: Template types, registry, useTemplateConfig hook, TemplateSkeleton, PageConfiguration migration, API route
+- [x] VASTU-1B-INFRA: Template types, registry, useTemplateConfig hook, TemplateSkeleton, PageConfiguration migration, API route
   - Files: `templates/types.ts`, `templates/registry.ts`, `templates/useTemplateConfig.ts`, `templates/TemplateSkeleton.tsx`, `schema.prisma`, `shared/types/page.ts`, `api/workspace/pages/[id]/config/route.ts`
 
 ---
@@ -221,11 +222,11 @@ Package: workspace, shared, shell | Agent: dev-engineer | Est: ~410 lines
 Branch: `feature/VASTU-1B-129-table-listing` (branch from main AFTER INFRA + US-128 merge)
 Package: workspace | Agent: dev-engineer + design-engineer | Est: ~620 lines
 
-- [ ] VASTU-1B-129a: TableListingTemplate with VastuTable integration and panel registration (workspace, L) [no deps] -- #223
+- [x] VASTU-1B-129a: TableListingTemplate with VastuTable integration and panel registration (workspace, L) [no deps] -- #223
   - Files: `templates/TableListing/TableListingTemplate.tsx`, `TableListingTemplate.module.css`, `panels/index.ts`
-- [ ] VASTU-1B-129b: KPISummaryStrip component + shared KPICard (workspace, M) [no deps, parallel with 129a] -- #224
+- [x] VASTU-1B-129b: KPISummaryStrip component + shared KPICard (workspace, M) [no deps, parallel with 129a] -- #224
   - Files: `templates/TableListing/KPISummaryStrip.tsx`, `components/KPICard/KPICard.tsx`
-- [ ] VASTU-1B-129c: TableListingTemplate tests (workspace, M) [deps: 129a, 129b] -- #225
+- [x] VASTU-1B-129c: TableListingTemplate tests (workspace, M) [deps: 129a, 129b] -- #225
   - Files: `templates/TableListing/__tests__/TableListingTemplate.test.tsx`
 
 ---
@@ -234,11 +235,11 @@ Package: workspace | Agent: dev-engineer + design-engineer | Est: ~620 lines
 Branch: `feature/VASTU-1B-130-summary-dashboard` (branch from main AFTER INFRA + US-135 merge)
 Package: workspace | Agent: design-engineer + dev-engineer | Est: ~850 lines
 
-- [ ] VASTU-1B-130a: SummaryDashboardTemplate with time range and KPI cards (workspace, L) [no deps] -- #226
+- [x] VASTU-1B-130a: SummaryDashboardTemplate with time range and KPI cards (workspace, L) [no deps] -- #226
   - Files: `templates/SummaryDashboard/SummaryDashboardTemplate.tsx`, `.module.css`, `TimeRangeControl.tsx`, `KPICardRow.tsx`, `panels/index.ts`
-- [ ] VASTU-1B-130b: ChartRow and MiniSummaryTable (workspace, M) [deps: 130a] -- #227
+- [x] VASTU-1B-130b: ChartRow and MiniSummaryTable (workspace, M) [deps: 130a] -- #227
   - Files: `templates/SummaryDashboard/ChartRow.tsx`, `MiniSummaryTable.tsx`
-- [ ] VASTU-1B-130c: SummaryDashboardTemplate tests (workspace, M) [deps: 130a, 130b] -- #228
+- [x] VASTU-1B-130c: SummaryDashboardTemplate tests (workspace, M) [deps: 130a, 130b] -- #228
   - Files: `templates/SummaryDashboard/__tests__/SummaryDashboardTemplate.test.tsx`
 
 ---
@@ -247,11 +248,11 @@ Package: workspace | Agent: design-engineer + dev-engineer | Est: ~850 lines
 Branch: `feature/VASTU-1B-131-multi-tab-detail` (branch from main AFTER INFRA + US-128 merge)
 Package: workspace | Agent: design-engineer + dev-engineer | Est: ~900 lines
 
-- [ ] VASTU-1B-131a: MultiTabDetailTemplate with EntityHeader and VastuTabs (workspace, L) [no deps] -- #229
+- [x] VASTU-1B-131a: MultiTabDetailTemplate with EntityHeader and VastuTabs (workspace, L) [no deps] -- #229
   - Files: `templates/MultiTabDetail/MultiTabDetailTemplate.tsx`, `.module.css`, `EntityHeader.tsx`, `panels/index.ts`
-- [ ] VASTU-1B-131b: MultiTabDetail tab content: Overview, sub-tables, Activity (workspace, M) [deps: 131a] -- #230
+- [x] VASTU-1B-131b: MultiTabDetail tab content: Overview, sub-tables, Activity (workspace, M) [deps: 131a] -- #230
   - Files: `templates/MultiTabDetail/tabs/OverviewTab.tsx`
-- [ ] VASTU-1B-131c: MultiTabDetailTemplate tests (workspace, M) [deps: 131a, 131b] -- #231
+- [x] VASTU-1B-131c: MultiTabDetailTemplate tests (workspace, M) [deps: 131a, 131b] -- #231
   - Files: `templates/MultiTabDetail/__tests__/MultiTabDetailTemplate.test.tsx`
 
 ---
@@ -260,11 +261,11 @@ Package: workspace | Agent: design-engineer + dev-engineer | Est: ~900 lines
 Branch: `feature/VASTU-1B-132-data-explorer` (branch from main AFTER INFRA + US-135 merge)
 Package: workspace | Agent: dev-engineer | Est: ~700 lines
 
-- [ ] VASTU-1B-132a: DataExplorerTemplate with controls and chart (workspace, L) [no deps] -- #232
+- [x] VASTU-1B-132a: DataExplorerTemplate with controls and chart (workspace, L) [no deps] -- #232
   - Files: `templates/DataExplorer/DataExplorerTemplate.tsx`, `.module.css`, `ExplorerControls.tsx`, `ChartTypeToggle.tsx`, `panels/index.ts`
-- [ ] VASTU-1B-132b: Data explorer companion table and export (workspace, M) [deps: 132a] -- #233
+- [x] VASTU-1B-132b: Data explorer companion table and export (workspace, M) [deps: 132a] -- #233
   - Files: `templates/DataExplorer/DataExplorerTemplate.tsx`
-- [ ] VASTU-1B-132c: DataExplorerTemplate tests (workspace, M) [deps: 132a, 132b] -- #234
+- [x] VASTU-1B-132c: DataExplorerTemplate tests (workspace, M) [deps: 132a, 132b] -- #234
   - Files: `templates/DataExplorer/__tests__/DataExplorerTemplate.test.tsx`
 
 ---
@@ -273,13 +274,13 @@ Package: workspace | Agent: dev-engineer | Est: ~700 lines
 Branch: `feature/VASTU-1B-133-form-page` (branch from main AFTER INFRA merges)
 Package: workspace | Agent: design-engineer + dev-engineer | Est: ~1000 lines
 
-- [ ] VASTU-1B-133a: FormPageTemplate single-page mode with validation (workspace, L) [no deps] -- #235
+- [x] VASTU-1B-133a: FormPageTemplate single-page mode with validation (workspace, L) [no deps] -- #235
   - Files: `templates/FormPage/FormPageTemplate.tsx`, `FormPageTemplate.module.css`, `panels/index.ts`
-- [ ] VASTU-1B-133b: FormWizard multi-step mode with stepper (workspace, L) [deps: 133a] -- #236
+- [x] VASTU-1B-133b: FormWizard multi-step mode with stepper (workspace, L) [deps: 133a] -- #236
   - Files: `templates/FormPage/FormWizard.tsx`, `templates/FormPage/SearchOrCreate.tsx`
-- [ ] VASTU-1B-133c: Form auto-save draft and dirty state detection (workspace, M) [deps: 133a] -- #237
+- [x] VASTU-1B-133c: Form auto-save draft and dirty state detection (workspace, M) [deps: 133a] -- #237
   - Files: `templates/FormPage/useFormDraft.ts`
-- [ ] VASTU-1B-133d: FormPageTemplate tests (workspace, M) [deps: 133a, 133b, 133c] -- #238
+- [x] VASTU-1B-133d: FormPageTemplate tests (workspace, M) [deps: 133a, 133b, 133c] -- #238
   - Files: `templates/FormPage/__tests__/FormPageTemplate.test.tsx`
 
 ---
@@ -288,11 +289,11 @@ Package: workspace | Agent: design-engineer + dev-engineer | Est: ~1000 lines
 Branch: `feature/VASTU-1B-134-timeline-activity` (branch from main AFTER INFRA merges)
 Package: workspace | Agent: design-engineer + dev-engineer | Est: ~760 lines
 
-- [ ] VASTU-1B-134a: TimelineActivityTemplate with event stream and date grouping (workspace, L) [no deps] -- #239
+- [x] VASTU-1B-134a: TimelineActivityTemplate with event stream and date grouping (workspace, L) [no deps] -- #239
   - Files: `templates/TimelineActivity/TimelineActivityTemplate.tsx`, `.module.css`, `TimelineEvent.tsx`, `DateGroupHeader.tsx`, `panels/index.ts`
-- [ ] VASTU-1B-134b: TimelineFilters and view toolbar integration (workspace, M) [deps: 134a] -- #240
+- [x] VASTU-1B-134b: TimelineFilters and view toolbar integration (workspace, M) [deps: 134a] -- #240
   - Files: `templates/TimelineActivity/TimelineFilters.tsx`
-- [ ] VASTU-1B-134c: TimelineActivityTemplate tests (workspace, M) [deps: 134a, 134b] -- #241
+- [x] VASTU-1B-134c: TimelineActivityTemplate tests (workspace, M) [deps: 134a, 134b] -- #241
   - Files: `templates/TimelineActivity/__tests__/TimelineActivityTemplate.test.tsx`
 
 ---
@@ -301,15 +302,15 @@ Package: workspace | Agent: design-engineer + dev-engineer | Est: ~760 lines
 Branch: `feature/VASTU-1B-136-builder-mode` (branch from main AFTER US-120 + INFRA merge)
 Package: workspace, shared, shell | Agent: dev-engineer + design-engineer | Est: ~2310 lines
 
-- [ ] VASTU-1B-136a: BuilderPanel shell, warning header, section navigation, and builderStore (workspace, M) [no deps] -- #242
+- [x] VASTU-1B-136a: BuilderPanel shell, warning header, section navigation, and builderStore (workspace, M) [no deps] -- #242
   - Files: `BuilderPanel/BuilderPanel.tsx`, `.module.css`, `BuilderWarningHeader.tsx`, `stores/builderStore.ts`
-- [ ] VASTU-1B-136b: Builder DataSource and FieldConfig sections (workspace, L) [deps: 136a] -- #243
+- [x] VASTU-1B-136b: Builder DataSource and FieldConfig sections (workspace, L) [deps: 136a] -- #243
   - Files: `BuilderPanel/sections/DataSourceSection.tsx`, `FieldConfigSection.tsx`
-- [ ] VASTU-1B-136c: Builder Sections, DefaultView, Permissions, and Hooks sections (workspace, L) [deps: 136a] -- #244
+- [x] VASTU-1B-136c: Builder Sections, DefaultView, Permissions, and Hooks sections (workspace, L) [deps: 136a] -- #244
   - Files: `BuilderPanel/sections/SectionsLayoutSection.tsx`, `DefaultViewSection.tsx`, `PermissionsSection.tsx`, `HooksSection.tsx`
-- [ ] VASTU-1B-136d: Builder PageMetadata, EphemeralToggle sections and API route (workspace+shell, M) [deps: 136a] -- #245
+- [x] VASTU-1B-136d: Builder PageMetadata, EphemeralToggle sections and API route (workspace+shell, M) [deps: 136a] -- #245
   - Files: `BuilderPanel/sections/PageMetadataSection.tsx`, `EphemeralToggleSection.tsx`, `api/workspace/pages/[id]/config/route.ts`
-- [ ] VASTU-1B-136e: BuilderPanel tests (workspace, L) [deps: 136a, 136b, 136c, 136d] -- #246
+- [x] VASTU-1B-136e: BuilderPanel tests (workspace, L) [deps: 136a, 136b, 136c, 136d] -- #246
   - Files: `BuilderPanel/__tests__/BuilderPanel.test.tsx`
 
 ---
@@ -318,13 +319,13 @@ Package: workspace, shared, shell | Agent: dev-engineer + design-engineer | Est:
 Branch: `feature/VASTU-1B-137-dashboard-view` (branch from main AFTER INFRA + US-135 merge)
 Package: workspace | Agent: design-engineer + dev-engineer | Est: ~2060 lines
 
-- [ ] VASTU-1B-137a: DashboardTemplate with greeting header and card grid (workspace, L) [no deps] -- #247
+- [x] VASTU-1B-137a: DashboardTemplate with greeting header and card grid (workspace, L) [no deps] -- #247
   - Files: `templates/Dashboard/DashboardTemplate.tsx`, `.module.css`, `DashboardGreeting.tsx`, `DashboardCard.tsx`, `stores/dashboardStore.ts`, `panels/index.ts`
-- [ ] VASTU-1B-137b: Dashboard card types (KPI, Chart, Table, Pipeline, QuickActions, Alert) (workspace, L) [deps: 137a] -- #248
+- [x] VASTU-1B-137b: Dashboard card types (KPI, Chart, Table, Pipeline, QuickActions, Alert) (workspace, L) [deps: 137a] -- #248
   - Files: `templates/Dashboard/cards/KPICard.tsx`, `ChartCard.tsx`, `TableCard.tsx`, `PipelineCard.tsx`, `QuickActionsCard.tsx`, `AlertCard.tsx`
-- [ ] VASTU-1B-137c: Dashboard EditGridMode and AddCardDialog (workspace, L) [deps: 137a, 137b] -- #249
+- [x] VASTU-1B-137c: Dashboard EditGridMode and AddCardDialog (workspace, L) [deps: 137a, 137b] -- #249
   - Files: `templates/Dashboard/EditGridMode.tsx`, `AddCardDialog.tsx`
-- [ ] VASTU-1B-137d: PinToDashboardDialog and dashboard tests (workspace, L) [deps: 137a, 137b, 137c] -- #250
+- [x] VASTU-1B-137d: PinToDashboardDialog and dashboard tests (workspace, L) [deps: 137a, 137b, 137c] -- #250
   - Files: `templates/Dashboard/PinToDashboardDialog.tsx`, `__tests__/DashboardTemplate.test.tsx`
 
 ---
@@ -333,13 +334,13 @@ Package: workspace | Agent: design-engineer + dev-engineer | Est: ~2060 lines
 Branch: `feature/VASTU-1B-127-e2e-tests` (branch from main AFTER all features merge)
 Package: workspace | Agent: qa-engineer | Est: ~830 lines
 
-- [ ] VASTU-1B-127a: E2E fixtures: page objects and seed data (workspace, M) [no deps] -- #251
+- [x] VASTU-1B-127a: E2E fixtures: page objects and seed data (workspace, M) [no deps] -- #251
   - Files: `e2e/fixtures/workspace-page.ts`, `e2e/fixtures/seed-data.ts`
-- [ ] VASTU-1B-127b: E2E: workspace load, sidebar, panels, tray (workspace, L) [deps: 127a] -- #252
+- [x] VASTU-1B-127b: E2E: workspace load, sidebar, panels, tray (workspace, L) [deps: 127a] -- #252
   - Files: `e2e/workspace.spec.ts`
-- [ ] VASTU-1B-127c: E2E: command palette and mode switch (workspace, M) [deps: 127a] -- #253
+- [x] VASTU-1B-127c: E2E: command palette and mode switch (workspace, M) [deps: 127a] -- #253
   - Files: `e2e/command-palette.spec.ts`, `e2e/mode-switch.spec.ts`
-- [ ] VASTU-1B-127d: E2E: table interactions and view save/load (workspace, M) [deps: 127a] -- #254
+- [x] VASTU-1B-127d: E2E: table interactions and view save/load (workspace, M) [deps: 127a] -- #254
   - Files: `e2e/table-interactions.spec.ts`
 
 ---
@@ -411,23 +412,23 @@ Package: workspace | Agent: qa-engineer | Est: ~830 lines
 
 | Story | GitHub Issue | Status |
 |-------|-------------|--------|
-| US-120 | #166 | Open |
-| US-121 | #167 | Open |
-| US-122 | #168 | Open |
-| US-123 | #169 | Open |
-| US-124 | #170 | Open |
-| US-125 | #173 | Open |
-| US-126 | #174 | Open |
-| US-127 | #184 | Open |
-| US-128 | #175 | Open |
-| US-129 | #176 | Open |
-| US-130 | #177 | Open |
-| US-131 | #178 | Open |
-| US-132 | #179 | Open |
-| US-133 | #180 | Open |
-| US-134 | #181 | Open |
-| US-135 | #172 | Open |
-| US-136 | #182 | Open |
-| US-137 | #183 | Open |
-| US-138 | #171 | Open |
-| INFRA  | #222 | Open |
+| US-120 | #166 | Complete |
+| US-121 | #167 | Complete |
+| US-122 | #168 | Complete |
+| US-123 | #169 | Complete |
+| US-124 | #170 | Complete |
+| US-125 | #173 | Complete |
+| US-126 | #174 | Complete |
+| US-127 | #184 | Complete |
+| US-128 | #175 | Complete |
+| US-129 | #176 | Complete |
+| US-130 | #177 | Complete |
+| US-131 | #178 | Complete |
+| US-132 | #179 | Complete |
+| US-133 | #180 | Complete |
+| US-134 | #181 | Complete |
+| US-135 | #172 | Complete |
+| US-136 | #182 | Complete |
+| US-137 | #183 | Complete |
+| US-138 | #171 | Complete |
+| INFRA  | #222 | Complete |


### PR DESCRIPTION
## Summary

- Add Phase 1B completion report documenting all 19 user stories + 1 infra task (67 subtasks) delivered across 6 waves
- Update todo.md to final state with all tasks marked complete and status set to COMPLETE
- Completion report covers: feature inventory by wave, architecture decisions (ADR-007 through ADR-012), design system compliance, test coverage, new components/templates/stores/API routes, dependencies added, known issues, deferred items, bugs closed, merged PRs, and Phase 2 recommendations

## Phase 1B highlights

- 39 merged PRs, 201 files changed, ~33,400 lines added
- 6 page templates: table listing, summary dashboard, multi-tab detail, data explorer, form page, timeline/activity
- 12 new components including VastuChart, CommandPalette, RecordDrawer, BuilderPanel
- 9 workspace E2E spec files
- 3 new dependencies: @mantine/form, @mantine/spotlight, recharts
- 15 Phase 1A bugs resolved

## Test plan

- [x] completion.md follows the format established by Phase 0 completion doc
- [x] todo.md has all 67 subtasks checked off
- [x] No code changes -- documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)