### PR TITLE
docs(workspace): add Phase 1B feature documentation

### DIFF
--- a/packages/docs/content/docs/decisions/adr-007-template-registry.mdx
+++ b/packages/docs/content/docs/decisions/adr-007-template-registry.mdx
@@ -1,0 +1,51 @@
+---
+title: "ADR-007: Template Registry Pattern"
+description: Why templates are registered in a central registry rather than being imported directly or resolved via file-system conventions.
+---
+
+**Status:** Accepted
+**Phase:** 1B
+**Date:** 2026-03-21
+
+## Context
+
+The workspace needed a way to map page records (which store a `templateType` string in the database) to React components that render the page content inside Dockview panels. The mapping needed to:
+
+- Support multiple templates without importing all of them unconditionally
+- Allow templates to be added in future phases without modifying the panel renderer
+- Be inspectable at runtime (for the command palette and template picker)
+- Prevent duplicate registrations that would cause silent rendering bugs
+
+Three approaches were considered:
+
+1. **Direct switch/case** — the panel renderer has a switch on `templateType` and imports every template component.
+2. **File-system convention** — templates live in a known directory and are auto-imported with dynamic `import()` by path.
+3. **Explicit registry** — a `Map<TemplateType, TemplateRegistryEntry>` that is populated at module load time via `registerTemplate()` calls.
+
+## Decision
+
+Use the explicit registry pattern (option 3).
+
+Templates are registered via `registerTemplate(type, component, meta)` in side-effect files (e.g. `TableListing/register.ts`). The panel renderer calls `getTemplate(type)` to look up the component. The registry throws on duplicate registration.
+
+## Rationale
+
+**Against switch/case:** Adding a template requires modifying the panel renderer — a high-traffic file that would accumulate merge conflicts. It also unconditionally imports every template, increasing the initial bundle.
+
+**Against file-system convention:** Dynamic imports by path are opaque to TypeScript and lose compile-time safety on `TemplateType` values. The file-system layout becomes a contract that breaks on refactoring.
+
+**For explicit registry:** Registration is a one-line call at module scope, co-located with the template component. New templates are added without touching any shared file. The registry map is inspectable at runtime, which the command palette uses to enumerate available templates. Duplicate registration throws immediately, making accidental overwrites visible in development.
+
+The panel registry (Dockview panels) already used this pattern. Aligning templates to the same pattern keeps the mental model consistent.
+
+## Consequences
+
+- Templates must call `registerTemplate` before any panel mounts. A single `templates/index.ts` collects these side-effect imports.
+- `TemplateType` is a union type in `templates/types.ts`. Adding a new template requires adding its key to the union — this is intentional as it enforces compile-time exhaustiveness checks.
+- Test isolation requires `unregisterTemplate` / `clearTemplateRegistry` helpers, which are exported but marked "not for production use".
+
+## Files
+
+- `packages/workspace/src/templates/registry.ts`
+- `packages/workspace/src/templates/types.ts`
+- `packages/workspace/src/templates/useTemplateConfig.ts`

--- a/packages/docs/content/docs/decisions/adr-008-vastuchart.mdx
+++ b/packages/docs/content/docs/decisions/adr-008-vastuchart.mdx
@@ -1,0 +1,54 @@
+---
+title: "ADR-008: VastuChart as the Sole Charting Abstraction"
+description: Why all charts go through VastuChart rather than allowing direct Recharts usage.
+---
+
+**Status:** Accepted
+**Phase:** 1B
+**Date:** 2026-03-21
+
+## Context
+
+The workspace needs charts in several places: KPI sparklines, the summary dashboard, the data explorer, and dashboard card charts. The underlying library chosen is Recharts.
+
+The question was whether to use Recharts directly or introduce a wrapper component.
+
+Arguments for using Recharts directly:
+- Less indirection
+- Full access to all Recharts configuration options immediately
+
+Arguments for a wrapper:
+- Design system compliance (colors, typography, axis styles) enforced in one place
+- Consistent loading, error, and empty states
+- Accessible aria-labels applied consistently
+- Custom tooltip and legend replace Recharts defaults that do not match the design system
+- Series color palette enforced in order
+
+## Decision
+
+All charts in the workspace go through `VastuChart`. Importing from `recharts` directly is prohibited in workspace components.
+
+## Rationale
+
+When charts are built directly on Recharts, compliance requirements (color tokens, reduced-motion, custom legend format, aria-labels) drift across implementations because each developer must remember to apply them. A single `VastuChart` component applies all requirements once.
+
+The palette rule — colors must be assigned from `CHART_SERIES_COLORS` in order, never rearranged — cannot be enforced if each chart manages its own colors. `VastuChart` assigns colors automatically by series index, making the palette consistent across charts even as the data changes.
+
+Custom `ChartTooltip` and `ChartLegend` components replace the Recharts defaults because the defaults do not use design system tokens and are not interactive (the custom legend supports toggle and solo). Centralizing these makes tooltip and legend behavior uniform.
+
+The `onConfigChange` callback and `ChartConfigPanel` overlay give users runtime control over chart settings without requiring developer changes. If these were spread across individual chart implementations, each would need its own config panel.
+
+## Consequences
+
+- `recharts` is a direct dependency of `@vastu/workspace` but is not a public API surface.
+- `VastuChart` exposes the subset of Recharts configuration that the workspace needs via `ChartConfig`. Configuration options not in `ChartConfig` are not accessible without modifying `VastuChart`.
+- Adding a seventh chart type or a new config option requires a `VastuChart` change rather than a consumer change — this is intentional.
+
+## Files
+
+- `packages/workspace/src/components/VastuChart/VastuChart.tsx`
+- `packages/workspace/src/components/VastuChart/types.ts`
+- `packages/workspace/src/components/VastuChart/chartColors.ts`
+- `packages/workspace/src/components/VastuChart/ChartTooltip.tsx`
+- `packages/workspace/src/components/VastuChart/ChartLegend.tsx`
+- `packages/workspace/src/components/VastuChart/ChartConfigPanel.tsx`

--- a/packages/docs/content/docs/decisions/adr-009-drawer-to-panel.mdx
+++ b/packages/docs/content/docs/decisions/adr-009-drawer-to-panel.mdx
@@ -1,0 +1,44 @@
+---
+title: "ADR-009: Drawer-to-Panel Promotion Pattern"
+description: Why RecordDrawer and full Dockview panels share a content component tree, and how the promotion transition works.
+---
+
+**Status:** Accepted
+**Phase:** 1B
+**Date:** 2026-03-21
+
+## Context
+
+Users open records in `RecordDrawer` for quick inspection. Power users want to inspect a record alongside other panels — for example, comparing a customer record to a filtered table. This requires "promoting" the drawer view to a full Dockview panel without losing context (active tab, scroll position).
+
+Three approaches were considered:
+
+1. **Separate components** — `RecordDrawer` and the record detail panel are distinct components that duplicate the tab/field rendering.
+2. **Reuse via props** — the record detail panel renders the same content as the drawer by accepting an `isPanel` flag that adjusts chrome.
+3. **Shared content tree** — `RecordDrawer` and the panel both render the same inner content component (`RecordDetailContent`). The promotion hook closes the drawer and opens the panel, passing enough state for the panel to restore the same view.
+
+## Decision
+
+Share the content component tree (option 3). `RecordDrawer` and `record-detail` panels render the same inner component. The `useDrawerToPanel` hook handles the transition.
+
+## Rationale
+
+**Against separate components:** Maintaining two implementations of the same five-tab record detail is a maintenance liability. Any field, layout, or tab change would need to be applied in two places.
+
+**Against `isPanel` flag:** A boolean flag that changes significant rendering behavior is a code smell. The component tree diverges as new panel-specific features are added, and the flag becomes a growing conditional.
+
+**For shared content tree:** The inner content component (`RecordDetailContent`) has no knowledge of whether it is rendering inside a drawer or a panel. It receives a `recordId` and manages its own tab and scroll state. The drawer and panel are thin wrappers that provide chrome (drawer slide animation vs panel tab bar).
+
+The `useDrawerToPanel` hook captures the current `recordId` from `drawerStore`, closes the drawer, and calls `openPanel('record-detail', panelId)` using the `recordId` as the panel instance suffix. The panel component parses the `recordId` from its `panelId` on mount and restores the same record.
+
+## Consequences
+
+- The `record-detail` panel type must be registered in the panel registry. If it is not, `useDrawerToPanel` logs a warning and only closes the drawer.
+- The `panelId` convention `record-detail-{recordId}` means only one panel per record can be open at a time. Opening the same record again focuses the existing panel.
+- Active tab is not yet passed through the transition (Phase 1B known issue). The panel opens on the default tab rather than the drawer's last active tab. This will be resolved in Phase 2 when Dockview exposes a typed params API.
+
+## Files
+
+- `packages/workspace/src/hooks/useDrawerToPanel.ts`
+- `packages/workspace/src/stores/drawerStore.ts`
+- `packages/workspace/src/components/RecordDrawer/`

--- a/packages/docs/content/docs/decisions/adr-010-builder-config-storage.mdx
+++ b/packages/docs/content/docs/decisions/adr-010-builder-config-storage.mdx
@@ -1,0 +1,48 @@
+---
+title: "ADR-010: Builder Mode Config Storage"
+description: Why page configuration is stored as JSON in a database table rather than in code or environment variables.
+---
+
+**Status:** Accepted
+**Phase:** 1B
+**Date:** 2026-03-21
+
+## Context
+
+Builder mode lets administrators change a page's template, data source, fields, and permissions. These changes need to be persisted and take effect for all users without a deployment.
+
+Options considered:
+
+1. **Hardcoded in source** — template configuration lives in TypeScript files next to the template.
+2. **Environment variables / config files** — configuration stored in `.env` or JSON config files, deployed with the application.
+3. **Database JSON column** — configuration stored in a `page_configurations` table, retrieved at runtime via API.
+
+## Decision
+
+Store configuration as JSON in the `page_configurations` database table, fetched and persisted via `GET/PUT /api/workspace/pages/[id]/config`.
+
+## Rationale
+
+**Against hardcoded source:** Changes require a code change, review, and deployment. Builder mode's primary value proposition is non-developer configuration — requiring a deployment defeats the purpose.
+
+**Against environment variables:** Environment variable changes also require a deployment. Config files checked into source control have the same problem and add a file management burden.
+
+**For database JSON:** Configuration changes take effect immediately on the next page load. Non-technical administrators can use builder mode without involving engineers. The Prisma schema for `page_configurations` is simple: `pageId`, `config` (JSON), `updatedAt`, `updatedBy`. Rolling back is a data operation, not a deployment.
+
+An audit trail is written on every PUT — `audit_events` records who changed what configuration and when. This satisfies enterprise change-management requirements.
+
+The `builderStore` (Zustand) holds in-flight edits in memory without writing to the API until the user clicks "Save config". This gives the user a clear save/discard transaction rather than auto-saving partial configs.
+
+## Consequences
+
+- The `page_configurations` table must be migrated before builder mode works. The migration was added in Phase 1B.
+- API latency means configuration is not available on the very first render. `useTemplateConfig` handles this with a loading state; templates render a `TemplateSkeleton` until the config arrives.
+- A 404 from the config API means the page has no saved configuration. `useTemplateConfig` returns a sensible default, so pages render immediately after creation without a required builder step.
+- Hook execution code is stored in the config but is not executed in Phase 1B. Execution sandboxing is deferred to Phase 3.
+
+## Files
+
+- `packages/workspace/src/stores/builderStore.ts`
+- `packages/workspace/src/templates/useTemplateConfig.ts`
+- `packages/workspace/src/components/BuilderPanel/`
+- `packages/shared/prisma/schema.prisma` — `page_configurations` table

--- a/packages/docs/content/docs/decisions/adr-011-dashboard-card-grid.mdx
+++ b/packages/docs/content/docs/decisions/adr-011-dashboard-card-grid.mdx
@@ -1,0 +1,47 @@
+---
+title: "ADR-011: Dashboard Card Grid Implementation"
+description: Why the dashboard uses CSS Grid with the HTML5 Drag API rather than a third-party drag-and-drop library.
+---
+
+**Status:** Accepted
+**Phase:** 1B
+**Date:** 2026-03-21
+
+## Context
+
+The dashboard template needed a responsive card grid with drag-to-reorder in edit mode. The choices for drag-and-drop were:
+
+1. **Third-party library** — `dnd-kit`, `react-beautiful-dnd`, or similar.
+2. **HTML5 Drag API** — native browser drag events on card elements.
+
+The choices for the grid layout were:
+
+1. **Fixed column counts** — a 12-column grid with explicit column span values.
+2. **Auto-fill CSS Grid** — `grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))`.
+
+## Decision
+
+Use CSS Grid with `auto-fill` and `minmax(280px, 1fr)` for layout. Use the HTML5 Drag API for reorder in edit mode.
+
+## Rationale
+
+**Grid layout — against fixed 12 columns:** Fixed column grids require breakpoint management (`sm:col-span-6 md:col-span-4` etc.) and add significant complexity for a feature that is not the primary workspace surface. Auto-fill adapts naturally to any panel width, which is important because Dockview panels can be resized freely.
+
+**Grid layout — for auto-fill:** `minmax(280px, 1fr)` produces a natural 1-, 2-, or 3-column layout as the panel grows. Cards with `size: '2x1'` span two columns via `grid-column: span 2`. No JavaScript is needed to recompute columns on resize.
+
+**Drag API — against third-party library:** `dnd-kit` and `react-beautiful-dnd` are well-maintained but add 15–30 kB to the bundle. For the Phase 1B scope (desktop browser, no cross-list drag, no keyboard-sortable requirement), the native API is sufficient and has no bundle cost.
+
+**Drag API — for HTML5:** `dragstart`, `dragover`, and `drop` events are sufficient for card reorder within a single grid. The implementation stores a `draggedId` ref, computes the new order on drop, and calls `reorderCards`. Drop indicator rendering is handled with CSS.
+
+The `dashboardStore.reorderCards` action accepts an ordered array of IDs and recomputes `order` values, keeping the store as the single source of truth for card positions.
+
+## Consequences
+
+- Drag-to-reorder may have limited or no support on touch devices. A library-based fallback (e.g. `dnd-kit`) is the recommended upgrade path if mobile dashboard editing becomes a requirement.
+- The `reorderCards` action is idempotent — calling it with the same ID order produces no visible change.
+- Cards are serialized to the view store when the user saves. Layout is not auto-saved — unsaved edit mode changes are lost on page reload.
+
+## Files
+
+- `packages/workspace/src/templates/Dashboard/`
+- `packages/workspace/src/stores/dashboardStore.ts`

--- a/packages/docs/content/docs/decisions/adr-012-e2e-test-architecture.mdx
+++ b/packages/docs/content/docs/decisions/adr-012-e2e-test-architecture.mdx
@@ -1,0 +1,45 @@
+---
+title: "ADR-012: E2E Test Architecture for Workspace"
+description: Why workspace E2E tests use the page object pattern and where they live in the repository.
+---
+
+**Status:** Accepted
+**Phase:** 1B
+**Date:** 2026-03-21
+
+## Context
+
+Phase 1B added comprehensive E2E test coverage for all workspace features. Decisions were needed on:
+
+1. Where to place the workspace E2E specs within the monorepo
+2. How to structure tests for a feature-heavy, stateful UI
+3. How to share setup code across spec files
+
+## Decision
+
+Place workspace E2E specs under `packages/shell/e2e/workspace/` alongside the existing auth, admin, and settings suites. Use the **page object pattern** with a `WorkspacePage` fixture class.
+
+## Rationale
+
+**Co-location in shell:** The E2E tests require the full application stack — Next.js server, Postgres, Redis, Keycloak, MinIO. These are already set up for the shell package's existing E2E suites. Adding workspace specs to the same Playwright project reuses that infrastructure without duplication.
+
+Placing workspace E2E in `packages/workspace/e2e/` was considered but rejected: the workspace package is a React component library that is server-rendered through the shell. Running workspace E2E in isolation would require spinning up a separate test harness for the shell's routes, which is redundant.
+
+**Page object pattern:** A `WorkspacePage` fixture class encapsulates all workspace-specific Playwright interactions — opening panels, waiting for Dockview to settle, triggering the command palette, switching modes, and asserting on table state. Without this encapsulation, interaction code is duplicated across 9 spec files.
+
+The fixture extends Playwright's `test` function via `test.extend`, so specs import from `./fixtures` and get a pre-initialized `WorkspacePage` in the test function arguments.
+
+**One spec per feature domain:** Each of the 9 spec files covers a distinct domain (workspace load, sidebar, panel layout, command palette, mode switch, table interactions, view store, builder mode, dashboard view). This enables parallel execution without cross-spec interference. Seed data is reset before each suite using a Prisma-based seed helper.
+
+## Consequences
+
+- Running workspace E2E tests requires the full Docker Compose stack to be running (`docker compose up -d`).
+- CI configuration for workspace E2E needs a Docker Compose step before the Playwright run. This is not yet configured in GitHub Actions — it is listed in the Phase 1B known issues.
+- The `WorkspacePage` fixture is the single place to update when workspace UI changes that affect test interactions.
+- Tests run against seed data from `pnpm prisma:seed`. Tests that mutate data (view saves, builder config saves) should reset affected records in their `afterEach` or operate on isolated data namespaces.
+
+## Files
+
+- `packages/shell/e2e/workspace/` — 9 spec files
+- `packages/shell/e2e/workspace/fixtures.ts` — `WorkspacePage` fixture class
+- `packages/shell/e2e/workspace/seed-helpers.ts` — test data helpers

--- a/packages/docs/content/docs/decisions/meta.json
+++ b/packages/docs/content/docs/decisions/meta.json
@@ -1,4 +1,11 @@
 {
   "title": "Decisions",
-  "pages": []
+  "pages": [
+    "adr-007-template-registry",
+    "adr-008-vastuchart",
+    "adr-009-drawer-to-panel",
+    "adr-010-builder-config-storage",
+    "adr-011-dashboard-card-grid",
+    "adr-012-e2e-test-architecture"
+  ]
 }

--- a/packages/docs/content/docs/workspace/builder-mode.mdx
+++ b/packages/docs/content/docs/workspace/builder-mode.mdx
@@ -1,0 +1,145 @@
+---
+title: Builder Mode
+description: Builder mode — switching to builder, the 8-section config panel, builderStore, saving and discarding changes, and the page configuration API.
+---
+
+Builder mode lets administrators configure a page's template, data source, fields, and permissions at runtime — no deployment required. Configuration is stored as JSON in the database and applied immediately on save.
+
+## Prerequisites
+
+- Read [Templates](/docs/workspace/templates) — builder mode configures templates
+- CASL permission: user must have `configure` on `Page` or `manage` on `all`
+
+## Switching to builder mode
+
+Builder mode is per-panel. The `ModeSwitch` control in the panel tab bar shows `Editor | Builder | Workflow` segments. Users without the `configure` permission only see `Editor`.
+
+```ts
+import { usePanelStore } from '@vastu/workspace';
+
+// Read the current mode for a panel
+const mode = usePanelStore((s) => s.panelModes[panelId]);
+// 'editor' | 'builder' | 'workflow'
+
+// Switch programmatically
+usePanelStore.getState().setPanelMode(panelId, 'builder');
+```
+
+When a panel enters builder mode, it calls `builderStore.initPage(pageId, currentConfig)` to take a snapshot of the current config as the discard baseline.
+
+## Builder panel layout
+
+The builder panel (`BuilderPanel`) has two columns:
+- **Left column**: navigation between the 8 sections
+- **Right column**: the configuration UI for the selected section
+
+The 8 sections:
+
+| Section ID | Label | What it configures |
+|-----------|-------|-------------------|
+| `dataSource` | Data Source | Type (prisma/rest/graphql), endpoint, model, base filters |
+| `fieldConfig` | Fields | Which fields are visible, sortable, filterable; labels; widths |
+| `sectionsLayout` | Sections & Layout | Named sections, order, visibility |
+| `defaultView` | Default View | Default sort, default filters, default pagination |
+| `permissions` | Permissions | Roles that may view, edit, or delete records |
+| `hooks` | Hooks | Monaco editor for lifecycle hook code (execution deferred to Phase 3) |
+| `pageMetadata` | Page Metadata | Page title, description, icon |
+| `ephemeral` | Ephemeral Mode | Toggle that enables the Workflow mode tab |
+
+```ts
+import { useBuilderStore } from '@vastu/workspace';
+
+const setActiveSection = useBuilderStore((s) => s.setActiveSection);
+setActiveSection('fieldConfig');
+```
+
+Source: `packages/workspace/src/components/BuilderPanel/`
+
+## builderStore
+
+All in-flight edits are held in `builderStore` — they are not persisted until the user clicks "Save config".
+
+```ts
+import { useBuilderStore } from '@vastu/workspace';
+
+const {
+  activeSection,
+  getDraftConfig,
+  isPageDirty,
+  setActiveSection,
+  initPage,
+  updateDraftConfig,
+  discardChanges,
+  markSaved,
+} = useBuilderStore();
+```
+
+| Action | Signature | Description |
+|--------|-----------|-------------|
+| `initPage` | `(pageId, savedConfig) => void` | Snapshot config as the discard baseline |
+| `updateDraftConfig` | `(pageId, partial) => void` | Merge partial changes into the draft |
+| `setDraftConfig` | `(pageId, config) => void` | Replace the draft entirely |
+| `discardChanges` | `(pageId) => void` | Revert to the initPage snapshot |
+| `markSaved` | `(pageId) => void` | Clear the dirty flag after a successful save |
+| `getDraftConfig` | `(pageId) => TemplateConfig \| null` | Read the draft |
+| `isPageDirty` | `(pageId) => boolean` | True when draft differs from snapshot |
+
+Source: `packages/workspace/src/stores/builderStore.ts`
+
+## Save and discard
+
+The builder panel footer has "Discard" and "Save config" buttons. "Save config" is enabled when `isPageDirty(pageId)` is true.
+
+Saving calls the page configuration API and then `markSaved`:
+
+```ts
+import { useBuilderStore, useTemplateConfig } from '@vastu/workspace';
+
+async function saveBuilderConfig(pageId: string) {
+  const draft = useBuilderStore.getState().getDraftConfig(pageId);
+  if (!draft) return;
+
+  try {
+    await updateConfig(draft);             // PUT /api/workspace/pages/[id]/config
+    useBuilderStore.getState().markSaved(pageId);
+  } catch (err) {
+    showErrorToast('Failed to save config');
+  }
+}
+```
+
+"Discard" calls `discardChanges(pageId)` and reverts the UI to the snapshot taken when builder mode was entered. A `ConfirmDialog` prompts when there are unsaved changes and the user tries to leave builder mode.
+
+## Page configuration API
+
+Configuration is persisted to the `page_configurations` table via the shell API:
+
+| Method | URL | Description |
+|--------|-----|-------------|
+| `GET` | `/api/workspace/pages/[id]/config` | Fetch current config |
+| `PUT` | `/api/workspace/pages/[id]/config` | Save updated config |
+
+Every PUT writes an audit event to the `audit_events` table. The response body is `{ config: TemplateConfig }`.
+
+A 404 from GET means the page has no saved configuration — use the template's `defaultConfig` from the registry.
+
+## Dirty state and mode switching
+
+Switching a panel from Builder to Editor while the draft is dirty triggers a `ConfirmDialog`:
+
+```
+Unsaved changes
+You have unsaved builder changes. Discard them and switch to Editor?
+[ Keep editing ]  [ Discard and switch ]
+```
+
+If the user confirms, `discardChanges` is called and the mode switches. The prompt only appears when `isPageDirty` is true.
+
+<Callout type="warning">
+Hook execution is not yet implemented. The Hooks section shows a Monaco editor and stores the code in the config, but execution happens in Phase 3. A placeholder message is shown in the execution area.
+</Callout>
+
+## Related pages
+
+- [Templates](/docs/workspace/templates) — builder mode configures template type and options
+- [Confirm Dialogs](/docs/workspace/confirm-dialogs) — used when discarding unsaved changes

--- a/packages/docs/content/docs/workspace/charts.mdx
+++ b/packages/docs/content/docs/workspace/charts.mdx
@@ -1,0 +1,182 @@
+---
+title: Charts
+description: VastuChart component — 6 chart types, props API, color palette, ChartTooltip, ChartLegend, and ChartConfigPanel.
+---
+
+`VastuChart` is the only charting component you should use in the workspace. It wraps Recharts with design system compliance, a 10-color palette, custom tooltip and legend, and a collapsible config panel.
+
+Never import from `recharts` directly — always use `VastuChart`.
+
+## Prerequisites
+
+- Read [Workspace Overview](/docs/workspace/overview)
+
+## Basic usage
+
+```tsx
+import { VastuChart } from '@vastu/workspace';
+
+const data = [
+  { month: 'Jan', revenue: 42000, costs: 31000 },
+  { month: 'Feb', revenue: 55000, costs: 35000 },
+  { month: 'Mar', revenue: 61000, costs: 38000 },
+];
+
+const series = [
+  { dataKey: 'revenue', name: 'Revenue' },
+  { dataKey: 'costs',   name: 'Costs' },
+];
+
+<VastuChart
+  type="line"
+  data={data}
+  series={series}
+  config={{ xAxisKey: 'month' }}
+  ariaLabel="Monthly revenue vs costs, line chart"
+/>
+```
+
+Source: `packages/workspace/src/components/VastuChart/`
+
+## Chart types
+
+| `type` | Description |
+|--------|-------------|
+| `line` | Multi-series line chart with optional dots |
+| `bar` | Vertical bar chart; supports stacking and horizontal orientation |
+| `area` | Area chart with 8% fill opacity |
+| `donut` | Pie chart with inner radius |
+| `sparkline` | Minimal single-series line — no axes, legend, or grid |
+| `scatter` | XY scatter chart; each series needs `xDataKey` set |
+
+## VastuChart props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `type` | `ChartType` | required | Chart variant to render |
+| `data` | `ChartDataPoint[]` | required | Array of data objects |
+| `series` | `SeriesConfig[]` | required | Series definitions |
+| `config` | `ChartConfig` | `{}` | Chart configuration overrides |
+| `onConfigChange` | `(config) => void` | — | Enables the config gear button |
+| `loading` | `boolean` | `false` | Renders a skeleton |
+| `error` | `string \| null` | `null` | Renders the error state |
+| `onRetry` | `() => void` | — | Retry button in the error state |
+| `ariaLabel` | `string` | auto | Accessible description for screen readers |
+| `className` | `string` | — | CSS class on the root element |
+
+## SeriesConfig
+
+```ts
+interface SeriesConfig {
+  dataKey: string;    // Field name in each data object
+  name: string;       // Label for legend and tooltip
+  color?: string;     // Override; omit to use palette assignment
+  hidden?: boolean;   // Start hidden (retains palette slot)
+  xDataKey?: string;  // Scatter only: field name for X axis values
+}
+```
+
+When `color` is omitted, the series is automatically assigned a color from the 10-color palette in order.
+
+## ChartConfig
+
+```ts
+interface ChartConfig {
+  height?: number;                          // Default: 240 inline, 360 full-width
+  showLegend?: boolean;                     // Default: true
+  legendPosition?: 'top' | 'bottom' | 'left' | 'right';  // Default: 'bottom'
+  showAxisLabels?: boolean;                 // Default: true
+  xAxisLabel?: string;
+  yAxisLabel?: string;
+  scaleType?: 'linear' | 'log';            // Default: 'linear'
+  stacked?: boolean;                        // bar and area only
+  barOrientation?: 'vertical' | 'horizontal';  // Default: 'vertical'
+  referenceLines?: ReferenceLineConfig[];
+  xAxisKey?: string;                        // Field used for the X axis
+}
+```
+
+## Color palette
+
+Colors are assigned in fixed order from the `CHART_SERIES_COLORS` palette (Style Guide §10.2). The same series index always gets the same color across different charts, so the visual meaning is consistent.
+
+```ts
+import { CHART_SERIES_COLORS, getSeriesColor } from '@vastu/workspace';
+
+const firstSeriesColor = getSeriesColor(0);  // '#76B900'
+```
+
+Use the palette in order — never rearrange colors to "look better" on one chart.
+
+When more than 10 series are present, series 10 and above are rendered in `var(--v-text-tertiary)` to indicate overflow. Consider aggregating into an "Other" series instead.
+
+## Loading and error states
+
+```tsx
+<VastuChart
+  type="bar"
+  data={data}
+  series={series}
+  loading={isLoading}
+  error={error?.message}
+  onRetry={refetch}
+  ariaLabel="Sales by region"
+/>
+```
+
+The loading state renders a Mantine `Skeleton` at the configured height. The error state shows a message with an optional retry button. An empty `data` array shows the `EmptyState` component.
+
+## ChartConfigPanel
+
+When you provide `onConfigChange`, a gear icon appears in the chart's top-right corner. Clicking it opens the `ChartConfigPanel` overlay, which lets users adjust axis labels, scale type, legend position, and stacking.
+
+```tsx
+const [chartConfig, setChartConfig] = useState<ChartConfig>({});
+
+<VastuChart
+  type="bar"
+  data={data}
+  series={series}
+  config={chartConfig}
+  onConfigChange={setChartConfig}
+  ariaLabel="Revenue chart"
+/>
+```
+
+The config panel is inside the chart boundary — it does not affect surrounding layout.
+
+## ChartLegend interaction
+
+The legend is interactive. Click a series swatch to toggle that series on or off. Alt-click (or click when all others are off) to solo a series — all others hide. Click again to restore.
+
+The `sparkline` type always hides the legend.
+
+## Reference lines
+
+Overlay horizontal or vertical reference lines to mark thresholds:
+
+```tsx
+<VastuChart
+  type="line"
+  data={data}
+  series={series}
+  config={{
+    xAxisKey: 'month',
+    referenceLines: [
+      { y: 50000, label: 'Target', color: 'var(--v-status-success)' },
+    ],
+  }}
+  ariaLabel="Revenue with target line"
+/>
+```
+
+## Accessibility
+
+Provide a meaningful `ariaLabel` on every chart. The root element has `role="img"` and the label is read by screen readers. The data explorer template also provides a "View as table" toggle for full data access without a visual chart.
+
+Set `prefers-reduced-motion` in the OS or browser and all chart animations are automatically disabled.
+
+## Related pages
+
+- [Templates](/docs/workspace/templates) — templates like data explorer and summary dashboard use VastuChart
+- [Dashboard](/docs/workspace/dashboard) — chart cards on the dashboard use VastuChart

--- a/packages/docs/content/docs/workspace/command-palette.mdx
+++ b/packages/docs/content/docs/workspace/command-palette.mdx
@@ -1,0 +1,125 @@
+---
+title: Command Palette
+description: Global search and command overlay — keyboard shortcut, search categories, registering custom actions, and useCommandPaletteActions.
+---
+
+The command palette is a full-screen overlay for navigating pages, opening recent records, and running workspace commands. It opens with `⌘K` (macOS) or `Ctrl+K` (Windows/Linux).
+
+## Prerequisites
+
+- Read [Workspace Overview](/docs/workspace/overview)
+- Read [Panels](/docs/workspace/panels) — pages in the palette open panels
+
+## Opening the palette
+
+The keyboard shortcut is wired by `WorkspaceShell`. You can also open it programmatically:
+
+```ts
+import { useCommandPaletteStore } from '@vastu/workspace';
+
+useCommandPaletteStore.getState().open();
+```
+
+The palette is built on Mantine Spotlight (`@mantine/spotlight`). It is mounted once in `WorkspaceShell`.
+
+## Search categories
+
+The palette groups results into three sections:
+
+| Group | Description |
+|-------|-------------|
+| Pages | Registered panels from the panel registry — opens the panel on select |
+| Recent records | Last 5 records opened from a drawer (stored in `localStorage`) |
+| Commands | Static workspace commands (toggle sidebar, new panel, settings, shortcuts) |
+
+Type `>` to switch to **commands-only mode** — only commands appear, filtered by the text after `>`.
+
+## useCommandPaletteActions hook
+
+`useCommandPaletteActions` returns filtered, grouped actions for the current query. You use this when building a custom command palette UI or adding actions to another search surface.
+
+```ts
+import { useCommandPaletteActions } from '@vastu/workspace';
+
+function MySearch({ query }: { query: string }) {
+  const { pages, recent, commands, commandsOnly, total } =
+    useCommandPaletteActions(query);
+
+  return (
+    <>
+      {pages.map((action) => <Item key={action.id} action={action} />)}
+      {recent.map((action) => <Item key={action.id} action={action} />)}
+      {commands.map((action) => <Item key={action.id} action={action} />)}
+    </>
+  );
+}
+```
+
+| Return | Type | Description |
+|--------|------|-------------|
+| `pages` | `CommandPaletteAction[]` | Page actions (empty in commands-only mode) |
+| `recent` | `CommandPaletteAction[]` | Recent record actions (empty in commands-only mode) |
+| `commands` | `CommandPaletteAction[]` | Workspace commands |
+| `commandsOnly` | `boolean` | True when query starts with `>` |
+| `total` | `number` | Total visible action count |
+
+Source: `packages/workspace/src/hooks/useCommandPaletteActions.ts`
+
+## CommandPaletteAction
+
+```ts
+interface CommandPaletteAction {
+  id: string;
+  label: string;
+  group: 'pages' | 'recent' | 'commands';
+  description?: string;
+  iconName?: string;      // Tabler icon name, no "Icon" prefix
+  panelTypeId?: string;   // For pages: open this panel type
+  recordId?: string;      // For records: the record to open
+  pageId?: string;        // For records: which page hosts it
+  onActivate?: () => void;
+}
+```
+
+## Registering custom commands
+
+Add custom commands by extending the static command list. The recommended pattern is to pass the commands into `useCommandPaletteActions` via the workspace configuration:
+
+```ts
+// At workspace startup — before CommandPalette mounts
+import { registerWorkspaceCommand } from '@vastu/workspace';
+
+registerWorkspaceCommand({
+  id: 'cmd:export-csv',
+  label: 'Export current view as CSV',
+  iconName: 'Download',
+  group: 'commands',
+  onActivate: () => exportCurrentView(),
+});
+```
+
+<Callout type="info">
+`registerWorkspaceCommand` is planned for Phase 2. In Phase 1B, commands are defined in `buildStaticCommands` inside `useCommandPaletteActions.ts`. Extend that array to add project-specific commands.
+</Callout>
+
+## Recent records
+
+When a user opens a record in the drawer, call `addRecentRecord` to track it for the "Recent records" palette category:
+
+```ts
+import { addRecentRecord } from '@vastu/workspace';
+
+addRecentRecord({
+  id: customer.id,
+  title: customer.name,
+  type: 'Customer',
+  pageId: 'customers',
+});
+```
+
+Records are stored in `localStorage` under the key `vastu-recent-records`. The most recent 5 are shown.
+
+## Related pages
+
+- [Panels](/docs/workspace/panels) — pages listed in the palette map to panel type IDs
+- [Keyboard Shortcuts](/docs/workspace/keyboard-shortcuts) — `⌘K` is one of the global shortcuts

--- a/packages/docs/content/docs/workspace/confirm-dialogs.mdx
+++ b/packages/docs/content/docs/workspace/confirm-dialogs.mdx
@@ -1,0 +1,134 @@
+---
+title: Confirm Dialogs
+description: ConfirmDialog component — 3 variants, useConfirmDialog imperative hook, usage pattern, and provider requirements.
+---
+
+`ConfirmDialog` is the shared confirmation modal for all destructive and cautionary actions in the workspace. Every action that deletes, overwrites, or performs an irreversible side effect must go through a confirmation dialog.
+
+## Prerequisites
+
+- Read [Workspace Overview](/docs/workspace/overview)
+
+## useConfirmDialog (imperative hook)
+
+The recommended pattern is the imperative `useConfirmDialog` hook. It returns an async `confirm` function that shows the dialog and resolves with `true` (confirmed) or `false` (cancelled).
+
+```tsx
+import { useConfirmDialog } from '@vastu/workspace';
+
+function DeleteButton({ recordId }: { recordId: string }) {
+  const confirm = useConfirmDialog();
+
+  async function handleDelete() {
+    const confirmed = await confirm({
+      title: 'Delete record?',
+      description: 'This record will be permanently deleted. This action cannot be undone.',
+      variant: 'delete',
+    });
+
+    if (confirmed) {
+      await deleteRecord(recordId);
+    }
+  }
+
+  return <button onClick={handleDelete}>Delete</button>;
+}
+```
+
+No state management needed at the call site. The hook manages the dialog's open/close lifecycle internally.
+
+Multiple concurrent `confirm` calls are queued. Only one dialog is visible at a time; each resolves before the next appears.
+
+Source: `packages/workspace/src/components/ConfirmDialog/useConfirmDialog.ts`
+
+## ConfirmOptions
+
+```ts
+interface ConfirmOptions {
+  title: string;           // Dialog heading
+  description: string;     // Impact explanation
+  variant?: 'delete' | 'warning' | 'info';  // Default: 'delete'
+  confirmLabel?: string;   // Override the confirm button label
+  cancelLabel?: string;    // Override the cancel button label
+}
+```
+
+## Variants
+
+| Variant | Button color | Default confirm label | Use for |
+|---------|-------------|----------------------|---------|
+| `delete` | Red | "Delete" | Permanently deleting records, views, configs |
+| `warning` | Amber | "Continue" | Caution-level actions with side effects |
+| `info` | Blue | "OK" | Confirmations that are informational, not destructive |
+
+## ConfirmDialogProvider
+
+The imperative hook requires `<ConfirmDialogProvider>` in the component tree. `WorkspaceShell` includes it automatically. You do not need to add it manually if you are using `WorkspaceShell`.
+
+If you are using `ConfirmDialog` outside of `WorkspaceShell` (for example, in a shell package page), add the provider to your layout:
+
+```tsx
+import { ConfirmDialogProvider } from '@vastu/workspace';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <ConfirmDialogProvider>
+      {children}
+    </ConfirmDialogProvider>
+  );
+}
+```
+
+Calling `useConfirmDialog()` without a provider throws with a clear error message.
+
+## ConfirmDialog (controlled component)
+
+If you need direct control over the open/close state — for example, when building a custom dialog — use `ConfirmDialog` as a controlled component:
+
+```tsx
+import { ConfirmDialog } from '@vastu/workspace';
+
+function MyComponent() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Discard changes</button>
+      <ConfirmDialog
+        opened={open}
+        title="Discard changes?"
+        description="Your unsaved changes will be lost."
+        variant="warning"
+        confirmLabel="Discard"
+        onConfirm={() => { discardChanges(); setOpen(false); }}
+        onCancel={() => setOpen(false)}
+      />
+    </>
+  );
+}
+```
+
+## ConfirmDialog props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `opened` | `boolean` | required | Controls dialog visibility |
+| `title` | `string` | required | Heading text |
+| `description` | `string` | required | Body text explaining the impact |
+| `variant` | `ConfirmDialogVariant` | `'delete'` | Visual variant |
+| `confirmLabel` | `string` | variant default | Confirm button label |
+| `cancelLabel` | `string` | "Cancel" | Cancel button label |
+| `onConfirm` | `() => void` | required | Called when user confirms |
+| `onCancel` | `() => void` | required | Called on cancel, Escape, or click-outside |
+
+## Focus management
+
+The cancel button receives autofocus when the dialog opens. This prevents accidental Enter key confirmation. Pressing `Enter` after the dialog opens activates "Cancel", not "Confirm" — users must move focus to the confirm button explicitly.
+
+Source: `packages/workspace/src/components/ConfirmDialog/`
+
+## Related pages
+
+- [Views](/docs/workspace/views) — view delete uses ConfirmDialog
+- [Record Drawer](/docs/workspace/record-drawer) — record delete uses ConfirmDialog
+- [Builder Mode](/docs/workspace/builder-mode) — discard unsaved changes uses ConfirmDialog

--- a/packages/docs/content/docs/workspace/context-menus.mdx
+++ b/packages/docs/content/docs/workspace/context-menus.mdx
@@ -176,6 +176,10 @@ However, `VastuTable` uses virtualized rendering which means rows are not standa
 
 The menu container has `role="menu"`. Each `ContextMenuItem` button has `role="menuitem"`. When a submenu is present, the item also has `aria-haspopup="menu"` and `aria-expanded`. `ContextMenuGroup` uses `role="group"`. `ContextMenuDivider` uses `role="separator"`.
 
+All `ContextMenuItem` labels are rendered via the `TruncatedText` component. Long labels truncate with an ellipsis rather than wrapping or overflowing the menu boundary.
+
+These ARIA roles and the `TruncatedText` wrapping were added in Phase 1B (US-123) to resolve bugs [#139](https://github.com/your-org/vastu/issues/139) and [#140](https://github.com/your-org/vastu/issues/140).
+
 ## Related pages
 
 - [Tables](/docs/workspace/tables) — built-in cell context menu callbacks

--- a/packages/docs/content/docs/workspace/dashboard.mdx
+++ b/packages/docs/content/docs/workspace/dashboard.mdx
@@ -1,0 +1,187 @@
+---
+title: Dashboard
+description: Dashboard view — card types, edit mode, drag-to-reorder, pin-to-dashboard, and dashboardStore.
+---
+
+The dashboard is the `dashboard` template type. It renders a responsive card grid with a greeting header and six card types. Users can enter edit mode to reorder cards and add or remove them. Any view in the workspace can be pinned to the dashboard.
+
+## Prerequisites
+
+- Read [Templates](/docs/workspace/templates) — the dashboard is registered as the `dashboard` template
+- Read [Charts](/docs/workspace/charts) — chart cards use VastuChart
+
+## Card types
+
+| Type | Description |
+|------|-------------|
+| `kpi` | Metric with value, optional delta, and optional sparkline |
+| `chart` | Line, bar, area, or donut chart using VastuChart |
+| `table` | A compact data table with a "View all" link |
+| `pipeline` | Horizontal stacked bar showing stage distribution |
+| `quick-actions` | Grid of icon-button shortcuts to other pages |
+| `alert` | List of warning/error/info alerts with a "View all" link |
+
+## dashboardStore
+
+Card state is managed by `useDashboardStore`:
+
+```ts
+import { useDashboardStore } from '@vastu/workspace';
+
+const {
+  cards,
+  editMode,
+  addCard,
+  removeCard,
+  reorderCards,
+  resizeCard,
+  updateCard,
+  toggleEditMode,
+  setCards,
+} = useDashboardStore();
+```
+
+| Action | Signature | Description |
+|--------|-----------|-------------|
+| `addCard` | `(card: DashboardCard) => void` | Append a new card at the end |
+| `removeCard` | `(id: string) => void` | Remove a card and renumber `order` |
+| `reorderCards` | `(orderedIds: string[]) => void` | Reorder by providing the new ID sequence |
+| `resizeCard` | `(id, size: CardSize) => void` | Change a card's grid size |
+| `updateCard` | `(id, updates) => void` | Partial update to any card field |
+| `toggleEditMode` | `() => void` | Toggle between view and edit mode |
+| `setCards` | `(cards) => void` | Replace the entire card list (used on load) |
+
+Source: `packages/workspace/src/stores/dashboardStore.ts`
+
+## Card definitions
+
+Each card type has a typed definition that extends `DashboardCardBase`:
+
+```ts
+interface DashboardCardBase {
+  id: string;
+  type: DashboardCardType;
+  title: string;
+  size: '1x1' | '2x1' | '1x2';
+  order: number;
+}
+```
+
+### KPI card
+
+```ts
+interface KPICardDef extends DashboardCardBase {
+  type: 'kpi';
+  metric?: string;
+  value?: string;
+  delta?: string;
+  sparklineData?: Array<{ value: number }>;
+}
+```
+
+`delta` is a formatted string like `+12%` or `-3%`. A positive delta renders in green; negative in red.
+
+### Chart card
+
+```ts
+interface ChartCardDef extends DashboardCardBase {
+  type: 'chart';
+  chartType?: 'line' | 'bar' | 'area' | 'donut';
+  data?: DashboardChartDataPoint[];
+  series?: Array<{ dataKey: string; name: string }>;
+}
+```
+
+### Alert card
+
+```ts
+interface AlertCardDef extends DashboardCardBase {
+  type: 'alert';
+  alerts?: Array<{
+    id: string;
+    message: string;
+    severity: 'warning' | 'error' | 'info';
+  }>;
+  viewAllPageId?: string;
+}
+```
+
+## Grid layout
+
+The dashboard uses CSS Grid with auto-fill columns:
+
+```css
+grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+```
+
+Card sizes map to `grid-column` and `grid-row` spans:
+
+| Size | Columns | Rows |
+|------|---------|------|
+| `1x1` | 1 | 1 |
+| `2x1` | 2 | 1 |
+| `1x2` | 1 | 2 |
+
+## Edit mode and drag-to-reorder
+
+Enter edit mode by clicking the "Edit dashboard" button in the toolbar. In edit mode:
+
+- Cards show a drag handle and a remove button.
+- Drag a card using the HTML5 Drag API to reorder it.
+- A drop indicator shows where the card will land.
+- An "Add card" button opens the add card dialog.
+
+Exit edit mode by clicking "Done". Changes take effect immediately and are persisted when the user saves the current view.
+
+```ts
+// Toggle edit mode programmatically
+useDashboardStore.getState().toggleEditMode();
+```
+
+<Callout type="info">
+Drag-to-reorder uses the HTML5 Drag API. It works on desktop browsers. Touch device support may be limited; a library-based fallback is planned if mobile becomes a requirement.
+</Callout>
+
+## Pinning views to the dashboard
+
+Users can pin any view in the workspace to the dashboard via "Pin to dashboard" in the view toolbar's overflow menu. This opens `PinToDashboardDialog`, which lets the user choose a card type and title.
+
+```ts
+import { useDashboardStore } from '@vastu/workspace';
+
+// Pin a view as a table card
+useDashboardStore.getState().addCard({
+  id: crypto.randomUUID(),
+  type: 'table',
+  title: 'Active Customers',
+  size: '2x1',
+  order: 999,
+  viewAllPageId: 'customers',
+});
+```
+
+Source: `packages/workspace/src/components/PinToDashboardDialog/`
+
+## Persisting dashboard state
+
+Dashboard card state is serialized into the view store when the user saves a dashboard view. Use the serialization helpers:
+
+```ts
+import {
+  serializeDashboardState,
+  deserializeDashboardState,
+} from '@vastu/workspace';
+
+// Serialize before saving to viewStore
+const payload = serializeDashboardState(cards);
+
+// Deserialize when restoring from viewStore
+const cards = deserializeDashboardState(savedPayload);
+useDashboardStore.getState().setCards(cards);
+```
+
+## Related pages
+
+- [Templates](/docs/workspace/templates) — the dashboard is registered as `dashboard` template type
+- [Charts](/docs/workspace/charts) — chart cards render VastuChart
+- [Views](/docs/workspace/views) — dashboard layout is saved in view state

--- a/packages/docs/content/docs/workspace/filters.mdx
+++ b/packages/docs/content/docs/workspace/filters.mdx
@@ -34,6 +34,10 @@ const root: FilterGroup = {
 
 `FilterNode = FilterCondition | FilterGroup`. The root is always a `FilterGroup`.
 
+<Callout type="info">
+The `FilterNode` type was aligned to the Patterns Library specification in Phase 1B (US-122). If you have existing code that checks `mode` on a `FilterGroup`, that field has been removed — `mode` only exists on `FilterCondition`. The `FilterBar` `mode` prop now correctly propagates to all new conditions added in that session.
+</Callout>
+
 ## IER modes
 
 Every condition has a `mode`:

--- a/packages/docs/content/docs/workspace/keyboard-shortcuts.mdx
+++ b/packages/docs/content/docs/workspace/keyboard-shortcuts.mdx
@@ -1,0 +1,137 @@
+---
+title: Keyboard Shortcuts
+description: Global keyboard shortcuts — all bindings, useKeyboardShortcuts hook, context-aware suppression, and ShortcutsModal.
+---
+
+Keyboard shortcuts are registered via `useKeyboardShortcuts`. The hook mounts a `keydown` listener on `window` and dispatches to registered handlers, suppressing shortcuts when focus is inside an input field.
+
+## Prerequisites
+
+- Read [Workspace Overview](/docs/workspace/overview)
+
+## Global shortcuts
+
+Press `?` from anywhere in the workspace (outside an input) to open the shortcuts reference modal. The full list of built-in bindings:
+
+| Shortcut | Group | Description |
+|----------|-------|-------------|
+| `⌘K` / `Ctrl+K` | General | Open command palette |
+| `?` | General | Open keyboard shortcuts reference |
+| `⌘B` / `Ctrl+B` | General | Toggle sidebar |
+| `Escape` | General | Close open overlay (drawer, dialog, menu) |
+| `⌘S` / `Ctrl+S` | General | Save current view |
+| `[` | Sidebar | Collapse sidebar |
+| `]` | Sidebar | Expand sidebar |
+| `↑` | Table | Move selection up one row |
+| `↓` | Table | Move selection down one row |
+| `Enter` | Table | Open selected row in drawer |
+| `⌘A` / `Ctrl+A` | Table | Select all rows |
+| `Delete` / `Backspace` | Table | Delete selected rows (triggers ConfirmDialog) |
+| `⌘↑` / `Ctrl+↑` | Drawer | Navigate to previous record |
+| `⌘↓` / `Ctrl+↓` | Drawer | Navigate to next record |
+| `Escape` | Drawer | Close drawer |
+
+Table and Drawer shortcuts are context-aware — they only fire when focus is inside the relevant element. General shortcuts fire anywhere.
+
+## useKeyboardShortcuts
+
+Call this hook at the layout level to register a list of shortcuts. Multiple calls from nested components accumulate — each component registers only its own shortcuts.
+
+```ts
+import {
+  useKeyboardShortcuts,
+  type ShortcutDefinition,
+} from '@vastu/workspace';
+
+const shortcuts: ShortcutDefinition[] = [
+  {
+    key: 'k',
+    modifiers: ['Meta'],
+    group: 'General',
+    description: 'Open command palette',
+    handler: openCommandPalette,
+  },
+  {
+    key: '?',
+    group: 'General',
+    description: 'Show keyboard shortcuts',
+    handler: openShortcutsModal,
+  },
+];
+
+function WorkspaceLayout() {
+  const { shortcuts: registeredShortcuts } = useKeyboardShortcuts(shortcuts);
+  // registeredShortcuts is the display list for ShortcutsModal
+
+  return <>{/* ... */}</>;
+}
+```
+
+Define the `shortcuts` array outside the component (or in `useMemo`) to keep the reference stable. Redefining it each render recreates the `keydown` listener unnecessarily.
+
+## ShortcutDefinition
+
+```ts
+interface ShortcutDefinition {
+  key: string;                              // e.g. 'k', 'Escape', '?', '['
+  modifiers?: ShortcutModifier[];           // 'Meta' | 'Ctrl' | 'Alt' | 'Shift'
+  contextRef?: React.RefObject<HTMLElement | null>;  // Scope to focused element
+  group: 'General' | 'Table' | 'Drawer' | 'Sidebar';
+  description: string;
+  handler: () => void;
+}
+```
+
+`'Meta'` matches `Cmd` on macOS and `Ctrl` on Windows/Linux automatically. Use `'Meta'` for cross-platform shortcuts instead of hardcoding `'Ctrl'`.
+
+## Context-aware suppression
+
+To scope a shortcut to a specific element — for example, table row navigation that only works when the table has focus — provide a `contextRef`:
+
+```ts
+const tableRef = useRef<HTMLDivElement>(null);
+
+const shortcuts: ShortcutDefinition[] = [
+  {
+    key: 'ArrowDown',
+    group: 'Table',
+    description: 'Move selection down',
+    handler: selectNextRow,
+    contextRef: tableRef,         // Only fires when tableRef contains focus
+  },
+];
+```
+
+The shortcut fires only when `contextRef.current` (or a descendant) is the active focused element.
+
+## Input suppression
+
+Shortcuts **without** a `Meta`/`Ctrl` modifier are automatically suppressed when focus is inside an `<input>`, `<textarea>`, `<select>`, or `[contenteditable]`. The `?` shortcut is always suppressed in input fields.
+
+`Meta`-modified shortcuts always fire regardless of focus — so `⌘K` works even when you are typing in the filter input.
+
+## ShortcutsModal
+
+`ShortcutsModal` renders the reference overlay. It is mounted once in `WorkspaceShell` and triggered by the `?` shortcut. You do not need to mount it manually.
+
+`useKeyboardShortcuts` returns a `shortcuts` array (type `ShortcutDisplayInfo[]`) that you can pass to `ShortcutsModal` if you build a custom implementation:
+
+```tsx
+import { ShortcutsModal } from '@vastu/workspace';
+
+<ShortcutsModal
+  opened={isOpen}
+  onClose={() => setIsOpen(false)}
+  shortcuts={registeredShortcuts}
+/>
+```
+
+The modal groups shortcuts by `group` and formats modifier keys with OS-appropriate symbols (⌘ on macOS, Ctrl on Windows/Linux).
+
+Source: `packages/workspace/src/hooks/useKeyboardShortcuts.ts`
+Source: `packages/workspace/src/components/ShortcutsModal/`
+
+## Related pages
+
+- [Command Palette](/docs/workspace/command-palette) — opened via `⌘K`
+- [Views](/docs/workspace/views) — `⌘S` saves the current view

--- a/packages/docs/content/docs/workspace/meta.json
+++ b/packages/docs/content/docs/workspace/meta.json
@@ -10,6 +10,14 @@
     "context-menus",
     "tray",
     "theming",
-    "authentication"
+    "authentication",
+    "templates",
+    "charts",
+    "record-drawer",
+    "command-palette",
+    "keyboard-shortcuts",
+    "builder-mode",
+    "dashboard",
+    "confirm-dialogs"
   ]
 }

--- a/packages/docs/content/docs/workspace/record-drawer.mdx
+++ b/packages/docs/content/docs/workspace/record-drawer.mdx
@@ -1,0 +1,179 @@
+---
+title: Record Drawer
+description: The slide-out record detail drawer — opening from table rows, 5 tabs, prev/next navigation, drawer-to-panel promotion, and drawerStore.
+---
+
+`RecordDrawer` is a slide-out panel that shows the details of a single record without leaving the current page. Users open it by clicking a row in a table, navigating through related records, and optionally promoting it to a full Dockview panel.
+
+## Prerequisites
+
+- Read [Panels](/docs/workspace/panels)
+- Read [Tables](/docs/workspace/tables)
+
+## Opening the drawer
+
+Call `openDrawer` from `useDrawerStore`. Pass the record ID, and optionally the full navigation stack so the user can move forward and backward through the result set.
+
+```tsx
+import { useDrawerStore } from '@vastu/workspace';
+
+function CustomerTable({ rows }: { rows: Customer[] }) {
+  const openDrawer = useDrawerStore((s) => s.openDrawer);
+
+  const navigationStack = rows.map((r, i) => ({
+    recordId: r.id,
+    title: r.name,
+  }));
+
+  function handleRowClick(row: Customer, index: number) {
+    openDrawer(row.id, navigationStack, index);
+  }
+
+  // ...
+}
+```
+
+The `RecordDrawer` component should be mounted once at the workspace layout level — `WorkspaceShell` does this automatically. You do not need to render it per-panel.
+
+## Drawer tabs
+
+The drawer has five tabs:
+
+| Tab | ID | Content |
+|-----|----|---------|
+| Details | `details` | All record fields in a two-column layout |
+| Items | `items` | Related child records (sub-table) |
+| History | `history` | Audit trail for the record (from `/api/workspace/records/[id]/history`) |
+| Notes | `notes` | Freeform notes attached to the record (from `/api/workspace/records/[id]/notes`) |
+| Permissions | `permissions` | Per-object ACL editor (UI only in Phase 1B; enforcement in Phase 2) |
+
+Switch the active tab programmatically:
+
+```ts
+const setActiveTab = useDrawerStore((s) => s.setActiveTab);
+setActiveTab('history');
+```
+
+## drawerStore
+
+The drawer's state is managed by `useDrawerStore`:
+
+```ts
+import { useDrawerStore } from '@vastu/workspace';
+
+const {
+  isOpen,
+  recordId,
+  activeTab,
+  navigationStack,
+  navigationIndex,
+  openDrawer,
+  closeDrawer,
+  setActiveTab,
+  navigateToRecord,
+  goBack,
+  goForward,
+} = useDrawerStore();
+```
+
+| Action | Signature | Description |
+|--------|-----------|-------------|
+| `openDrawer` | `(recordId, stack?, index?) => void` | Open drawer for a record |
+| `closeDrawer` | `() => void` | Close and reset transient state |
+| `setActiveTab` | `(tab: DrawerTab) => void` | Switch the active tab |
+| `navigateToRecord` | `(recordId) => void` | Jump to a record without changing the stack |
+| `goBack` | `() => void` | Previous record in the navigation stack |
+| `goForward` | `() => void` | Next record in the navigation stack |
+
+Navigation clamps at the ends — it does not wrap. The prev/next buttons in the drawer footer are disabled when at the first or last record.
+
+Source: `packages/workspace/src/stores/drawerStore.ts`
+
+## Prev/next navigation
+
+When you pass a `navigationStack`, the drawer footer shows `‹ Previous` and `Next ›` buttons. The current position is shown as "3 of 47". Clicking prev or next calls `goBack`/`goForward` and fetches the adjacent record.
+
+Pass the navigation stack from the current table page:
+
+```ts
+// rows = current page from VastuTable (50 rows at a time)
+const stack = rows.map((r) => ({ recordId: r.id, title: r.name }));
+openDrawer(clickedRow.id, stack);
+```
+
+## Drawer-to-panel promotion
+
+Users can open the current drawer record as a full-size Dockview panel by clicking "Open in panel" in the drawer footer. This closes the drawer and opens a panel registered under the type ID `record-detail`.
+
+To support this, register a panel with `id: 'record-detail'` in your panel registry:
+
+```ts
+import { registerPanel } from '@vastu/workspace';
+import { RecordDetailPanel } from './RecordDetailPanel';
+
+registerPanel({
+  id: 'record-detail',
+  title: 'Record',
+  component: RecordDetailPanel,
+});
+```
+
+The promotion is handled by `useDrawerToPanel`:
+
+```ts
+import { useDrawerToPanel } from '@vastu/workspace';
+
+function DrawerFooter() {
+  const openInPanel = useDrawerToPanel();
+
+  return (
+    <button onClick={() => openInPanel()}>
+      Open in panel
+    </button>
+  );
+}
+```
+
+`useDrawerToPanel` closes the drawer and opens the panel. If no `record-detail` panel is registered it logs a warning and only closes the drawer.
+
+Source: `packages/workspace/src/hooks/useDrawerToPanel.ts`
+
+## API routes
+
+The drawer fetches record data from these shell API routes:
+
+| Method | URL | Description |
+|--------|-----|-------------|
+| `GET` | `/api/workspace/records/[id]` | Record fields for the Details tab |
+| `PUT` | `/api/workspace/records/[id]` | Save field edits |
+| `DELETE` | `/api/workspace/records/[id]` | Delete the record (triggers ConfirmDialog) |
+| `GET` | `/api/workspace/records/[id]/history` | Audit events for the History tab |
+| `GET` | `/api/workspace/records/[id]/notes` | Notes list for the Notes tab |
+| `POST` | `/api/workspace/records/[id]/notes` | Add a new note |
+
+## VastuTabs
+
+The drawer tabs are rendered by the `VastuTabs` component, which is also exported for use in other multi-tab surfaces:
+
+```tsx
+import { VastuTabs } from '@vastu/workspace';
+
+<VastuTabs
+  tabs={[
+    { id: 'overview', label: 'Overview' },
+    { id: 'activity', label: 'Activity' },
+  ]}
+  activeTab={activeTab}
+  onTabChange={setActiveTab}
+>
+  {/* render content for activeTab */}
+</VastuTabs>
+```
+
+Source: `packages/workspace/src/components/VastuTabs/`
+
+## Related pages
+
+- [Tables](/docs/workspace/tables) — trigger drawer from table row clicks
+- [Panels](/docs/workspace/panels) — register the `record-detail` panel for promotion
+- [Confirm Dialogs](/docs/workspace/confirm-dialogs) — delete action in the drawer footer

--- a/packages/docs/content/docs/workspace/templates.mdx
+++ b/packages/docs/content/docs/workspace/templates.mdx
@@ -1,0 +1,183 @@
+---
+title: Templates
+description: How the page template system works — registry pattern, template types, useTemplateConfig, TemplateSkeleton, and creating a new template.
+---
+
+Page templates are the content that renders inside Dockview panels. Each template is a React component registered under a string key. When a panel opens, it looks up the registered component by key and renders it with the page's configuration.
+
+## Prerequisites
+
+- Read [Panels](/docs/workspace/panels) — templates render inside panels
+- Read [Builder Mode](/docs/workspace/builder-mode) — configuration is edited in builder mode
+
+## Template registry
+
+Templates are registered at module load time, before any panel mounts. Registration maps a `TemplateType` string to a React component and metadata.
+
+```ts
+import { registerTemplate } from '@vastu/workspace';
+import { MyTemplate } from './MyTemplate';
+
+registerTemplate(
+  'table-listing',       // TemplateType key
+  MyTemplate,            // React component (receives TemplateProps)
+  {
+    label: 'Table Listing',
+    icon: 'Table',
+    description: 'A filterable table with KPI summary strip',
+    defaultConfig: {
+      templateType: 'table-listing',
+      fields: [],
+    },
+  },
+);
+```
+
+Registering the same key twice throws. Import registrations as side effects from a single entry file:
+
+```ts
+// templates/index.ts
+import './TableListing/register';
+import './SummaryDashboard/register';
+```
+
+### Registry API
+
+```ts
+import { getTemplate, getRegisteredTemplates } from '@vastu/workspace';
+
+const entry = getTemplate('table-listing');
+// entry.component — React component
+// entry.meta      — label, icon, description, defaultConfig
+
+const all = getRegisteredTemplates();
+// [{ type, component, meta }, ...]
+```
+
+`getRegisteredTemplates` is used by the command palette and template picker.
+
+## TemplateType values
+
+| Key | Component | Purpose |
+|-----|-----------|---------|
+| `table-listing` | `TableListingTemplate` | Filterable table with KPI strip, row click to drawer |
+| `summary-dashboard` | `SummaryDashboardTemplate` | Time range, KPI cards, charts, mini tables |
+| `multi-tab-detail` | `MultiTabDetailTemplate` | Entity header, RBAC-gated tabs, activity timeline |
+| `data-explorer` | `DataExplorerTemplate` | Metric/dimension controls, chart toggle, companion table, export |
+| `form-page` | `FormPageTemplate` | Single-page or wizard form with auto-save drafts |
+| `timeline-activity` | `TimelineActivityTemplate` | Date-grouped event stream with type filters, infinite scroll |
+| `dashboard` | `DashboardTemplate` | Card grid with KPI, chart, table, pipeline, quick-actions, alert cards |
+
+Source: `packages/workspace/src/templates/`
+
+## TemplateProps
+
+Every template component receives the same props interface:
+
+```ts
+interface TemplateProps {
+  pageId: string;
+  config: TemplateConfig;
+  onConfigChange?: (config: TemplateConfig) => void;
+  loading?: boolean;
+  error?: string | null;
+}
+```
+
+`onConfigChange` is only provided when the page is in Builder mode.
+
+## TemplateConfig
+
+The base configuration shape shared by all templates. Extended per-template via `metadata`.
+
+```ts
+interface TemplateConfig {
+  templateType: TemplateType;
+  dataSource?: DataSourceConfig;
+  fields?: FieldConfig[];
+  sections?: SectionConfig[];
+  permissions?: PermissionConfig;
+  metadata?: Record<string, unknown>;
+}
+```
+
+Configuration is stored as JSON in the `page_configurations` table and retrieved via `useTemplateConfig`.
+
+Source: `packages/workspace/src/templates/types.ts`
+
+## useTemplateConfig
+
+The hook that fetches and persists a page's configuration. Templates call this internally; you rarely need to call it directly.
+
+```ts
+import { useTemplateConfig } from '@vastu/workspace';
+
+function MyTemplate({ pageId }: TemplateProps) {
+  const { config, loading, error, updateConfig } = useTemplateConfig(pageId);
+
+  if (loading) return <TemplateSkeleton />;
+  if (error) return <ErrorState message={error} />;
+  if (!config) return null;
+
+  return <div>Rendering with {config.templateType}</div>;
+}
+```
+
+| Return | Type | Description |
+|--------|------|-------------|
+| `config` | `TemplateConfig \| null` | The resolved config, or `null` during first load |
+| `loading` | `boolean` | True while the initial fetch is in flight |
+| `error` | `string \| null` | Non-null when fetch or save failed |
+| `updateConfig` | `(config) => Promise<void>` | Persist updated config; uses optimistic update |
+
+When the API returns 404 (unconfigured page), the hook returns a sensible default so templates render without an explicit save.
+
+Routes: `GET /api/workspace/pages/[id]/config` and `PUT /api/workspace/pages/[id]/config`.
+
+## TemplateSkeleton
+
+A loading skeleton that matches the height and layout of a template panel. Use it as the loading state for all templates.
+
+```tsx
+import { TemplateSkeleton } from '@vastu/workspace';
+
+if (loading) return <TemplateSkeleton />;
+```
+
+`TemplateSkeleton` follows the design system's skeleton → content → error pattern.
+
+## Creating a new template
+
+1. Create the component in `packages/workspace/src/templates/YourTemplate/`.
+2. Implement `TemplateProps`. Call `useTemplateConfig` for config if needed.
+3. Create a `register.ts` side-effect file:
+
+```ts
+// templates/YourTemplate/register.ts
+import { registerTemplate } from '@vastu/workspace';
+import { YourTemplate } from './YourTemplate';
+
+registerTemplate('your-key' as TemplateType, YourTemplate, {
+  label: 'Your Template',
+  icon: 'Layout',
+  description: 'What this template does.',
+  defaultConfig: { templateType: 'your-key' as TemplateType },
+});
+```
+
+4. Import the registration from `templates/index.ts`.
+5. Add a panel registration so the template opens in a Dockview panel (see [Panels](/docs/workspace/panels)).
+
+## Zero-config rendering
+
+All built-in templates render with mock/seed data when no configuration has been saved. This means the page is usable immediately after creation without a builder setup step. Templates progressively enhance as the builder configuration is filled in.
+
+<Callout type="info">
+Templates currently render seed data. Real external database queries are planned for Phase 2.
+</Callout>
+
+## Related pages
+
+- [Panels](/docs/workspace/panels) — templates render inside registered panels
+- [Builder Mode](/docs/workspace/builder-mode) — how templates are configured at runtime
+- [Dashboard](/docs/workspace/dashboard) — the dashboard template has additional card management

--- a/packages/docs/content/docs/workspace/views.mdx
+++ b/packages/docs/content/docs/workspace/views.mdx
@@ -27,6 +27,10 @@ interface ViewState {
 
 `scrollPosition` is excluded from the "is modified" comparison — scrolling never marks a view as dirty.
 
+<Callout type="info">
+The `ViewState` shape was corrected in Phase 1B (US-121) to include `scrollPosition` and fix several missing fields. If you serialized `ViewState` during Phase 1A, re-save those views — the shape has changed.
+</Callout>
+
 ## useViewStore
 
 The view store is headless. `ViewToolbar` consumes it, but you can also read from it directly to react to view changes.
@@ -110,10 +114,14 @@ function MyPanelToolbar() {
 ```
 
 - The **view name** is inline-editable. Click it to rename. Press Enter or blur to commit. Press Escape to cancel.
-- The **modified indicator** (goldenrod dot + "Modified" label + "Reset" link) appears when `isModified()` is true.
+- The **modified indicator** (goldenrod dot + "Modified" label + "Reset" link) appears when `isModified()` is true. This indicator was added in Phase 1B (US-121) — it was not present in Phase 1A.
 - The **Save button** is active (blue) when modified, dimmed when clean.
 - **⌘S / Ctrl+S** triggers Save from anywhere in the toolbar. It does not interfere with other input fields.
 - **Share** and **⋯ overflow** are rendered as disabled placeholders — they will be activated in a future phase.
+
+### View delete confirmation
+
+Deleting a view from the `⋯` overflow menu shows a `ConfirmDialog` before proceeding. This was added in Phase 1B (US-121) to fix bug [#144](https://github.com/your-org/vastu/issues/144). See [Confirm Dialogs](/docs/workspace/confirm-dialogs).
 
 ## ViewSelector
 


### PR DESCRIPTION
## Summary

- **8 new workspace docs**: templates, charts, record drawer, command palette, keyboard shortcuts, builder mode, dashboard, confirm dialogs
- **6 new ADR pages**: ADR-007 through ADR-012 covering template registry, VastuChart, drawer-to-panel, builder config storage, dashboard card grid, E2E test architecture
- **3 updated docs**: context-menus (ARIA improvements), filters (FilterNode alignment), views (ViewState fixes)
- Updated `meta.json` navigation for workspace and decisions sections

## Test plan

- [ ] Run `pnpm --filter docs build` to verify all MDX pages compile
- [ ] Verify new pages appear in sidebar navigation under Workspace and Decisions
- [ ] Spot-check code examples render correctly
- [ ] Confirm internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)