### PR TITLE
ci(workspace): add workspace E2E workflow [VASTU-2A-211]

### DIFF
--- a/.github/workflows/ci-workspace-e2e.yml
+++ b/.github/workflows/ci-workspace-e2e.yml
@@ -1,0 +1,183 @@
+name: 'E2E: Workspace'
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/workspace/**'
+      - 'packages/shell/e2e/workspace/**'
+      - 'packages/shell/src/app/workspace/**'
+      - 'packages/shared/src/prisma/**'
+      - '.github/workflows/ci-workspace-e2e.yml'
+
+concurrency:
+  group: e2e-workspace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  e2e-workspace:
+    name: 'E2E: Workspace'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: vastu
+          POSTGRES_PASSWORD: vastu
+          POSTGRES_DB: vastu
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U vastu -d vastu"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://vastu:vastu@localhost:5432/vastu
+      REDIS_URL: redis://localhost:6379
+      AUTH_SECRET: ci-test-secret-not-for-production
+      NEXTAUTH_URL: http://localhost:3000
+      KEYCLOAK_URL: http://localhost:8080
+      KEYCLOAK_REALM: vastu
+      KEYCLOAK_CLIENT_ID: vastu-app
+      KEYCLOAK_CLIENT_SECRET: dev-secret
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Start Keycloak manually (not as a service container) so we can mount
+      # the realm export from the checked-out repo. Uses H2 embedded DB to
+      # avoid a Keycloak-specific Postgres database setup step.
+      - name: Start Keycloak
+        run: |
+          docker run -d --name keycloak \
+            --network host \
+            -e KEYCLOAK_ADMIN=admin \
+            -e KEYCLOAK_ADMIN_PASSWORD=admin \
+            -e KC_HEALTH_ENABLED=true \
+            -v ${{ github.workspace }}/docker/keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro \
+            quay.io/keycloak/keycloak:24.0 \
+            start-dev --import-realm
+
+          echo "Waiting for Keycloak to become ready..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8080/health/ready > /dev/null 2>&1; then
+              echo "Keycloak is ready (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Keycloak failed to start within 5 minutes"
+              docker logs keycloak
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-e2e-workspace-${{ github.sha }}
+          restore-keys: |
+            turbo-e2e-workspace-
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: packages/shell/.next/cache
+          key: nextjs-e2e-workspace-${{ runner.os }}-${{ hashFiles('packages/shell/src/**', 'packages/workspace/src/**') }}
+          restore-keys: |
+            nextjs-e2e-workspace-${{ runner.os }}-
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('packages/shell/package.json') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm prisma:generate
+
+      - name: Push database schema
+        run: pnpm --filter @vastu/shared exec prisma db push --schema=./src/prisma/schema.prisma --skip-generate
+
+      - name: Seed auth and base data
+        run: pnpm prisma:seed
+
+      - name: Create Keycloak users and link accounts
+        run: pnpm --filter @vastu/shared exec tsx ${{ github.workspace }}/packages/shell/e2e/seed-keycloak-accounts.ts
+
+      - name: Create .env for Next.js dev server
+        run: |
+          echo "AUTH_SECRET=$AUTH_SECRET" > packages/shell/.env
+          echo "NEXTAUTH_URL=$NEXTAUTH_URL" >> packages/shell/.env
+          echo "DATABASE_URL=$DATABASE_URL" >> packages/shell/.env
+          echo "REDIS_URL=$REDIS_URL" >> packages/shell/.env
+          echo "KEYCLOAK_URL=$KEYCLOAK_URL" >> packages/shell/.env
+          echo "KEYCLOAK_REALM=$KEYCLOAK_REALM" >> packages/shell/.env
+          echo "KEYCLOAK_CLIENT_ID=$KEYCLOAK_CLIENT_ID" >> packages/shell/.env
+          echo "KEYCLOAK_CLIENT_SECRET=$KEYCLOAK_CLIENT_SECRET" >> packages/shell/.env
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @vastu/shell exec playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @vastu/shell exec playwright install-deps chromium
+
+      - name: Run workspace E2E tests
+        run: pnpm --filter @vastu/shell exec playwright test e2e/workspace/
+
+      - name: Upload Playwright traces on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-traces-workspace
+          path: packages/shell/test-results/
+          retention-days: 14
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-workspace
+          path: packages/shell/playwright-report/
+          retention-days: 30
+
+      - name: Keycloak logs on failure
+        if: failure()
+        run: docker logs keycloak


### PR DESCRIPTION
## Summary
- GitHub Actions workflow for workspace E2E tests with Postgres, Redis, Keycloak service containers
- Seeds auth + base data before test execution
- Playwright trace upload on failure, HTML report always uploaded
- 3 caches (Turbo, Next.js, Playwright browsers) for sub-10-minute runs
- Path-filtered triggers on PRs, always runs on main

## Test plan
- [ ] Verify workflow triggers on workspace file changes
- [ ] Verify service containers start and are healthy
- [ ] Verify seed completes before test execution
- [ ] Verify traces uploaded on failure
- [ ] Verify total time under 10 minutes

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)